### PR TITLE
Migrate config API to configurable variables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ ext.testngVersion = "6.14.3"
 ext.slf4jVersion = "1.7.30"
 ext.stdlibIoVersion = project.stdlibIoVersion
 ext.stdlibRegexVersion = project.stdlibRegexVersion
-ext.stdlibConfigVersion = project.stdlibConfigVersion
 ext.stdlibOsVersion = project.stdlibOsVersion
 
 allprojects {
@@ -77,14 +76,6 @@ allprojects {
         }
 
         maven {
-            url = 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-config'
-            credentials {
-                username System.getenv("packageUser")
-                password System.getenv("packagePAT")
-            }
-        }
-
-        maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/module-ballerina-os'
             credentials {
                 username System.getenv("packageUser")
@@ -104,7 +95,6 @@ subprojects {
         /* Standard libraries */
         ballerinaStdLibs "org.ballerinalang:io-ballerina:${stdlibIoVersion}"
         ballerinaStdLibs "org.ballerinalang:regex-ballerina:${stdlibRegexVersion}"
-        ballerinaStdLibs "org.ballerinalang:config-ballerina:${stdlibConfigVersion}"
         ballerinaStdLibs "org.ballerinalang:os-ballerina:${stdlibOsVersion}"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,6 @@ org.gradle.caching=true
 group=org.ballerinalang
 version=1.0.5-SNAPSHOT
 ballerinaLangVersion=2.0.0-Preview9-SNAPSHOT
-stdlibConfigVersion=1.0.5-SNAPSHOT
 stdlibIoVersion=0.5.5-SNAPSHOT
 stdlibOsVersion=0.7.0-SNAPSHOT
 stdlibRegexVersion=0.6.0-SNAPSHOT

--- a/log-integration-tests/Ballerina.toml
+++ b/log-integration-tests/Ballerina.toml
@@ -15,11 +15,6 @@ version = "@stdlib.regex.version@"
 
 [[dependency]]
 org = "ballerina"
-name = "config"
-version = "@stdlib.config.version@"
-
-[[dependency]]
-org = "ballerina"
 name = "os"
 version = "@stdlib.os.version@"
 

--- a/log-integration-tests/build.gradle
+++ b/log-integration-tests/build.gradle
@@ -88,19 +88,19 @@ task copyStdlibs(type: Copy) {
 def ballerinaConfigFile = new File("$project.projectDir/Ballerina.toml")
 def tomlVersion = project.version.split("-")[0]
 def originalConfig = ballerinaConfigFile.text
+def configTOMLFile = new File("$project.projectDir/tests/Config.toml")
+def initialTOMLcontent = configTOMLFile.text
 
 task updateTomlVerions {
     doLast {
         def stdlibDependentIoVersion = project.stdlibIoVersion.split("-")[0]
         def stdlibDependentRegexVersion = project.stdlibRegexVersion.split("-")[0]
-        def stdlibDependentConfigVersion = project.stdlibConfigVersion.split("-")[0]
         def stdlibDependentOsVersion = project.stdlibOsVersion.split("-")[0]
 
         def newConfig = ballerinaConfigFile.text.replace("@project.version@", project.version)
         newConfig = newConfig.replace("@toml.version@", tomlVersion)
         newConfig = newConfig.replace("@stdlib.io.version@", stdlibDependentIoVersion)
         newConfig = newConfig.replace("@stdlib.regex.version@", stdlibDependentRegexVersion)
-        newConfig = newConfig.replace("@stdlib.config.version@", stdlibDependentConfigVersion)
         newConfig = newConfig.replace("@stdlib.os.version@", stdlibDependentOsVersion)
         ballerinaConfigFile.text = newConfig
     }
@@ -109,7 +109,12 @@ task updateTomlVerions {
 task revertTomlFile {
     doLast {
         ballerinaConfigFile.text = originalConfig
+        configTOMLFile.text = initialTOMLcontent
     }
+}
+
+def setExecPath(configTOMLFile, distributionBinPath) {
+    configTOMLFile.text = configTOMLFile.text.replace("@exec.path@", distributionBinPath)
 }
 
 task ballerinaIntegrationTests {
@@ -120,13 +125,14 @@ task ballerinaIntegrationTests {
     finalizedBy(revertTomlFile)
     doLast {
         def distributionBinPath =  project.projectDir.absolutePath + "/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
+        setExecPath(configTOMLFile,distributionBinPath)
         exec {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/bal.bat test --bal_exec_path=${distributionBinPath}/bal"
+                commandLine 'cmd', '/c', "$distributionBinPath/bal.bat test"
             } else {
-                commandLine 'sh', '-c', "$distributionBinPath/bal test --bal_exec_path=${distributionBinPath}/bal"
+                commandLine 'sh', '-c', "$distributionBinPath/bal test"
             }
         }
     }

--- a/log-integration-tests/tests/Config.toml
+++ b/log-integration-tests/tests/Config.toml
@@ -1,0 +1,2 @@
+[integration_tests]
+bal_exec_path = "@exec.path@/bal"

--- a/log-integration-tests/tests/tests.bal
+++ b/log-integration-tests/tests/tests.bal
@@ -1,10 +1,8 @@
-import ballerina/config;
 import ballerina/io;
 import ballerina/os;
 import ballerina/regex;
 import ballerina/test;
 
-const BAL_EXEC_PATH = "bal_exec_path";
 const INCORRECT_NUMBER_OF_LINES = "incorrect number of lines in output";
 const UTF_8 = "UTF-8";
 const LOG_LEVEL_TEST_FILE = "tests/resources/log_level_test.bal";
@@ -17,9 +15,11 @@ const string KEY_VALUE_FOO = "foo = true";
 const string KEY_VALUE_ID = "id = 845315";
 const string KEY_VALUE_USERNAME = "username = " + "\"" + "Alex92" + "\"";
 
+configurable string bal_exec_path = ?;
+
 @test:Config {}
 public function testSingleFile() {
-    os:Process|error execResult = os:exec(config:getAsString(BAL_EXEC_PATH), {}, (), "run", LOG_LEVEL_TEST_FILE);
+    os:Process|error execResult = os:exec(bal_exec_path, {}, (), "run", LOG_LEVEL_TEST_FILE);
     os:Process result = checkpanic execResult;
     int waitForExit = checkpanic result.waitForExit();
     int exitCode = checkpanic result.exitCode();


### PR DESCRIPTION
## Purpose
$subject

## Goals
N/A

## Approach
Removed usage of config API to pass execution path. Instead, added a build task to write the configuration file for a configurable variable.

## User stories
N/A

## Release note
N/A

## Documentation
[BBE](https://ballerina.io/swan-lake/learn/by-example/configurable.html)

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
    Modified existing ones 
 - Integration tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)

## Test environment
Ubuntu 20.04 , jdk 11.0

## Learning
N/A
