### PR TITLE
 Publish Code Coverage Exec Files and Enable publishing testable jars 

### DIFF
--- a/log-ballerina/build.gradle
+++ b/log-ballerina/build.gradle
@@ -60,8 +60,6 @@ task unpackStdLibs() {
 }
 
 task copyStdlibs(type: Copy) {
-    dependsOn(unpackJballerinaTools)
-    dependsOn(unpackStdLibs)
     def ballerinaDist = "build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}"
     into ballerinaDist
 
@@ -125,13 +123,6 @@ task initializeVariables {
 }
 
 task ballerinaTest {
-    dependsOn(":log-native:build")
-    dependsOn(":log-test-utils:build")
-    dependsOn(copyStdlibs)
-    dependsOn(updateTomlVerions)
-    dependsOn(initializeVariables)
-    finalizedBy(revertTomlFile)
-
     doLast {
         exec {
             workingDir project.projectDir
@@ -148,20 +139,8 @@ task ballerinaTest {
     }
 }
 
-test {
-    dependsOn(ballerinaTest)
-}
-
 task ballerinaBuild {
     inputs.dir file(project.projectDir)
-    dependsOn(":log-native:build")
-    dependsOn(":log-test-utils:build")
-    dependsOn(copyStdlibs)
-    dependsOn(updateTomlVerions)
-    dependsOn(test)
-    dependsOn(initializeVariables)
-    finalizedBy(revertTomlFile)
-    finalizedBy(':log-integration-tests:build')
 
     def testParams = "--skip-tests"
     gradle.taskGraph.whenReady { graph ->
@@ -260,6 +239,24 @@ publishing {
     }
 }
 
-build {
-    dependsOn(ballerinaBuild)
-}
+copyStdlibs.dependsOn unpackStdLibs
+copyStdlibs.dependsOn unpackJballerinaTools
+
+ballerinaTest.dependsOn ":log-native:build"
+ballerinaTest.dependsOn ":log-test-utils:build"
+ballerinaTest.dependsOn copyStdlibs
+ballerinaTest.dependsOn updateTomlVerions
+ballerinaTest.dependsOn initializeVariables
+ballerinaTest.finalizedBy revertTomlFile
+test.dependsOn ballerinaTest
+
+
+ballerinaBuild.dependsOn ":log-native:build"
+ballerinaBuild.dependsOn ":log-test-utils:build"
+ballerinaBuild.dependsOn copyStdlibs
+ballerinaBuild.dependsOn updateTomlVerions
+ballerinaBuild.dependsOn initializeVariables
+ballerinaBuild.dependsOn test
+ballerinaBuild.finalizedBy revertTomlFile
+ballerinaBuild.finalizedBy ':log-integration-tests:build'
+build.dependsOn ballerinaBuild

--- a/log-ballerina/build.gradle
+++ b/log-ballerina/build.gradle
@@ -77,12 +77,13 @@ task copyStdlibs(type: Copy) {
 
 def packageName = "log"
 def packageOrg = "ballerina"
+def tomlVersion = project.version.split("-")[0]
 def ballerinaConfigFile = new File("${project.projectDir}/Ballerina.toml")
 def artifactBallerinaDocs = file("${project.projectDir}/build/docs_parent/")
 def artifactCacheParent = file("${project.projectDir}/build/cache_parent/")
 def artifactLibParent = file("${project.projectDir}/build/lib_parent/")
 def artifactCodeCoverageReport = file("${project.projectDir}/target/cache/tests_cache/coverage/ballerina.exec")
-def tomlVersion = project.version.split("-")[0]
+def artifactTestableJar = file("$project.projectDir/target/cache/${packageOrg}/${packageName}/${tomlVersion}/java11/")
 def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
 def originalConfig = ballerinaConfigFile.text
 def distributionBinPath =  project.projectDir.absolutePath + "/build/target/extracted-distributions/" +
@@ -144,10 +145,10 @@ task ballerinaBuild {
 
     def testParams = "--skip-tests"
     gradle.taskGraph.whenReady { graph ->
-        if (graph.hasTask(':log-ballerina:build') || graph.hasTask(':log-ballerina:publish')) {
+        if (graph.hasTask(":${packageName}-ballerina:build") || graph.hasTask(":${packageName}-ballerina:publish")) {
             ballerinaTest.enabled = false
         }
-        if (graph.hasTask(':log-ballerina:test')) {
+        if (graph.hasTask(":${packageName}-ballerina:test")) {
             testParams = "--code-coverage --includes=*"
         }
     }
@@ -215,8 +216,12 @@ task createArtifactZip(type: Zip) {
     from ballerinaBuild
 }
 
-def getCheckedOutGitCommitHash() {
-    'git rev-parse --verify --short HEAD'.execute().text.trim()
+task createTestableJarZip(type: Zip) {
+    archiveName("${packageOrg}-${packageName}-${project.version}-testable-jars.zip")
+    destinationDir(file("${buildDir}/distributions"))
+    from ("${artifactTestableJar}") {
+        include '**/*-testable.jar'
+    }
 }
 
 publishing {
@@ -224,6 +229,7 @@ publishing {
         maven(MavenPublication) {
             artifact source: createArtifactZip, extension: 'zip'
             artifact source: artifactCodeCoverageReport, classifier: 'jacoco'
+            artifact source: createTestableJarZip, classifier: 'testable-jars', extension: 'zip'
         }
     }
 
@@ -260,3 +266,5 @@ ballerinaBuild.dependsOn test
 ballerinaBuild.finalizedBy revertTomlFile
 ballerinaBuild.finalizedBy ':log-integration-tests:build'
 build.dependsOn ballerinaBuild
+
+createTestableJarZip.dependsOn ballerinaBuild

--- a/log-ballerina/build.gradle
+++ b/log-ballerina/build.gradle
@@ -32,13 +32,12 @@ dependencies {
 }
 
 clean {
-    delete "$project.projectDir/target"
+    delete "${project.projectDir}/target"
 }
 
 jar {
     manifest {
-        attributes('Implementation-Title': project.name,
-                'Implementation-Version': project.version)
+        attributes('Implementation-Title': project.name, 'Implementation-Version': project.version)
     }
 }
 
@@ -80,11 +79,11 @@ task copyStdlibs(type: Copy) {
 
 def packageName = "log"
 def packageOrg = "ballerina"
-def ballerinaConfigFile = new File("$project.projectDir/Ballerina.toml")
-def artifactBallerinaDocs = file("$project.projectDir/build/docs_parent/")
-def artifactCacheParent = file("$project.projectDir/build/cache_parent/")
-def artifactLibParent = file("$project.projectDir/build/lib_parent/")
-def artifactCodeCoverageReport = file("$project.projectDir/target/cache/tests_cache/coverage/ballerina.exec")
+def ballerinaConfigFile = new File("${project.projectDir}/Ballerina.toml")
+def artifactBallerinaDocs = file("${project.projectDir}/build/docs_parent/")
+def artifactCacheParent = file("${project.projectDir}/build/cache_parent/")
+def artifactLibParent = file("${project.projectDir}/build/lib_parent/")
+def artifactCodeCoverageReport = file("${project.projectDir}/target/cache/tests_cache/coverage/ballerina.exec")
 def tomlVersion = project.version.split("-")[0]
 def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
 def originalConfig = ballerinaConfigFile.text
@@ -138,11 +137,11 @@ task ballerinaTest {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat test " +
+                commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat test " +
                         "--code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams} && " +
                         "exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal test " +
+                commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal test " +
                         "--code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams}"
             }
         }
@@ -180,21 +179,21 @@ task ballerinaBuild {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat build " +
-                        "$testParams ${debugParams} && exit %%ERRORLEVEL%%"
+                commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat build " +
+                        "${testParams} ${debugParams} && exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal build $testParams ${debugParams}"
+                commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal build ${testParams} ${debugParams}"
             }
         }
         copy {
-            from file("$project.projectDir/target/bala")
-            into file("$artifactCacheParent/bala/${packageOrg}/${packageName}/${tomlVersion}")
+            from file("${project.projectDir}/target/bala")
+            into file("${artifactCacheParent}/bala/${packageOrg}/${packageName}/${tomlVersion}")
         }
         copy {
-            from file("$project.projectDir/target/cache")
+            from file("${project.projectDir}/target/cache")
             exclude '**/*-testable.jar'
             exclude '**/tests_cache/'
-            into file("$artifactCacheParent/cache/")
+            into file("${artifactCacheParent}/cache/")
         }
 
         // Publish to central
@@ -204,9 +203,9 @@ task ballerinaBuild {
                 workingDir project.projectDir
                 environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
                 if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
+                    commandLine 'cmd', '/c', "${distributionBinPath}/bal.bat push && exit %%ERRORLEVEL%%"
                 } else {
-                    commandLine 'sh', '-c', "$distributionBinPath/bal push"
+                    commandLine 'sh', '-c', "${distributionBinPath}/bal push"
                 }
             }
 
@@ -216,14 +215,14 @@ task ballerinaBuild {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/bal.bat doc && exit %%ERRORLEVEL%%"
+                commandLine 'cmd', '/c', "${distributionBinPath}/bal.bat doc && exit %%ERRORLEVEL%%"
             } else {
-                commandLine 'sh', '-c', "$distributionBinPath/bal doc"
+                commandLine 'sh', '-c', "${distributionBinPath}/bal doc"
             }
         }
         copy {
-            from file("$project.projectDir/target/apidocs/${packageName}")
-            into file("$project.projectDir/build/docs_parent/docs/${packageName}")
+            from file("${project.projectDir}/target/apidocs/${packageName}")
+            into file("${project.projectDir}/build/docs_parent/docs/${packageName}")
         }
     }
 
@@ -233,8 +232,12 @@ task ballerinaBuild {
 }
 
 task createArtifactZip(type: Zip) {
-    destinationDirectory = file("$buildDir/distributions")
+    destinationDirectory = file("${buildDir}/distributions")
     from ballerinaBuild
+}
+
+def getCheckedOutGitCommitHash() {
+    'git rev-parse --verify --short HEAD'.execute().text.trim()
 }
 
 publishing {


### PR DESCRIPTION
## Purpose
> Publish exec file generate by the testerina as a Maven artifact and enable to publish testable jar files. With this PR exec file will be named as log-ballerina-<version>-jacoco.exec and testable jars will be named as log-ballerina-<version>-testable-jars.zip
