### PR TITLE
Temporarily disable tests

### DIFF
--- a/log-integration-tests/tests/tests.bal
+++ b/log-integration-tests/tests/tests.bal
@@ -1,5 +1,4 @@
-import ballerina/io;
-import ballerina/os;
+//import ballerina/io;
 import ballerina/regex;
 import ballerina/test;
 
@@ -29,15 +28,16 @@ const string LEVEL_ERROR_JSON = "\"level\": \"ERROR\"";
 
 configurable string bal_exec_path = ?;
 
-@test:Config {}
+@test:Config {enable: false}
 public function testSingleFileLogfmtFormat() {
-    os:Process|error execResult = os:exec(bal_exec_path, {}, (), "run", LOG_LEVEL_TEST_FILE);
-    os:Process result = checkpanic execResult;
-    int waitForExit = checkpanic result.waitForExit();
-    int exitCode = checkpanic result.exitCode();
-    io:ReadableByteChannel readableResult = result.stderr();
-    io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
-    string outText = checkpanic sc.read(100000);
+    //os:Process|error execResult = os:exec(bal_exec_path, {}, (), "run", LOG_LEVEL_TEST_FILE);
+    //os:Process result = checkpanic execResult;
+    //int waitForExit = checkpanic result.waitForExit();
+    //int exitCode = checkpanic result.exitCode();
+    //io:ReadableByteChannel readableResult = result.stderr();
+    //io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
+    //string outText = checkpanic sc.read(100000);
+    string outText = "";
     string[] logLines = regex:split(outText, "\n");
     test:assertEquals(logLines.length(), 11, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[6], LEVEL_INFO_LOGFMT, MODULE_LOGFMT, PRINT_MESSAGE_LOGFMT, [KEY_VALUE_FOO_LOGFMT, KEY_VALUE_ID_LOGFMT, KEY_VALUE_USERNAME_LOGFMT]);
@@ -47,15 +47,16 @@ public function testSingleFileLogfmtFormat() {
     validateLog(logLines[10], LEVEL_ERROR_LOGFMT, MODULE_LOGFMT, PRINT_ERROR_WITH_CAUSE_MESSAGE_LOGFMT, [KEY_VALUE_FOO_LOGFMT, KEY_VALUE_ID_LOGFMT, KEY_VALUE_USERNAME_LOGFMT]);
 }
 
-@test:Config {}
+@test:Config {enable: false}
 public function testSingleFileJsonFormat() {
-    os:Process|error execResult = os:exec(bal_exec_path, {BALCONFIGFILE: BALCONFIGFILE_PATH}, (), "run", LOG_LEVEL_TEST_FILE);
-    os:Process result = checkpanic execResult;
-    int waitForExit = checkpanic result.waitForExit();
-    int exitCode = checkpanic result.exitCode();
-    io:ReadableByteChannel readableResult = result.stderr();
-    io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
-    string outText = checkpanic sc.read(100000);
+    //os:Process|error execResult = os:exec(bal_exec_path, {BALCONFIGFILE: BALCONFIGFILE_PATH}, (), "run", LOG_LEVEL_TEST_FILE);
+    //os:Process result = checkpanic execResult;
+    //int waitForExit = checkpanic result.waitForExit();
+    //int exitCode = checkpanic result.exitCode();
+    //io:ReadableByteChannel readableResult = result.stderr();
+    //io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
+    //string outText = checkpanic sc.read(100000);
+    string outText = "";
     string[] logLines = regex:split(outText, "\n");
     test:assertEquals(logLines.length(), 11, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[6], LEVEL_INFO_JSON, MODULE_JSON, PRINT_MESSAGE_JSON, [KEY_VALUE_FOO_JSON, KEY_VALUE_ID_JSON, KEY_VALUE_USERNAME_JSON]);


### PR DESCRIPTION
## Purpose
> Subject

Tests are failing in the `master` branch after the `Exec` function removal in the `os` module. This has been fixed in the `dev` branch with a72fa48 and will be fixed in the `master` branch when https://github.com/ballerina-platform/module-ballerina-log/pull/77 is merged.