### PR TITLE
Improve the behavior of escaping characters in log output

### DIFF
--- a/ changelog.md
+++ b/ changelog.md
@@ -4,6 +4,9 @@ This file contains all the notable changes done to the Ballerina TCP package thr
 ## [Unreleased]
 
 ### Added
+- [[1395] Add function to write log output to a file](https://github.com/ballerina-platform/ballerina-standard-library/issues/1395)
+
+### Added
 - [[#1342] Add Observability span context to log messages when Observability is enabled.](https://github.com/ballerina-platform/ballerina-standard-library/issues/1342)
 
 ## [1.1.0-alpha8] - 2021-04-22

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -39,6 +39,21 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "log"
+version = "2.0.0"
+transitive = false
+dependencies = [
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "observe"},
+	{org = "ballerina", name = "test"}
+]
+modules = [
+	{org = "ballerina", packageName = "log", moduleName = "log"}
+]
+
+[[package]]
+org = "ballerina"
 name = "observe"
 version = "0.9.0"
 transitive = false

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -32,9 +32,12 @@ modules = [
 org = "ballerina"
 name = "lang.value"
 version = "0.0.0"
-transitive = true
+transitive = false
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.value", moduleName = "lang.value"}
 ]
 
 [[package]]
@@ -45,6 +48,7 @@ transitive = false
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "observe"},
 	{org = "ballerina", name = "test"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -22,7 +22,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "jballerina.java"
-version = "0.9.0"
+version = "0.0.0"
 transitive = false
 modules = [
 	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
@@ -31,7 +31,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "lang.value"
-version = "1.0.0"
+version = "0.0.0"
 transitive = true
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -53,7 +53,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "test"
-version = "0.8.0"
+version = "0.0.0"
 scope = "testOnly"
 transitive = false
 dependencies = [

--- a/ballerina/natives.bal
+++ b/ballerina/natives.bal
@@ -193,7 +193,7 @@ isolated function print(string logLevel, string msg, error? err = (), *KeyValues
         if path is string {
             fileWrite(logOutput);
         } else {
-            println(stderrStream(), java:fromString(logOutput));
+            io:fprintln(io:stderr, logOutput);
         }
     }
 }
@@ -211,17 +211,6 @@ isolated function fileWrite(string logOutput) {
         }
     }
 }
-
-isolated function println(handle receiver, handle msg) = @java:Method {
-    name: "println",
-    'class: "java.io.PrintStream",
-    paramTypes: ["java.lang.String"]
-} external;
-
-isolated function stderrStream() returns handle = @java:FieldGet {
-    name: "err",
-    'class: "java/lang/System"
-} external;
 
 isolated function printLogFmt(LogRecord logRecord) returns string {
     string message = "";

--- a/ballerina/natives.bal
+++ b/ballerina/natives.bal
@@ -16,6 +16,7 @@
 
 import ballerina/io;
 import ballerina/observe;
+import ballerina/lang.'value;
 import ballerina/jballerina.java;
 
 # Represents log level types.
@@ -168,7 +169,12 @@ isolated function print(string logLevel, string msg, error? err = (), *KeyValues
         message: msg
     };
     if err is error {
-        logRecord["error"] = err.message();
+        json|error errMessage = value:fromJsonString(err.message());
+        if errMessage is json {
+            logRecord["error"] = errMessage;
+        } else {
+            logRecord["error"] = err.message();   
+        }
     }
     foreach [string, Value] [k, v] in keyValues.entries() {
         anydata value = v is Valuer ? v() : v;

--- a/ballerina/tests/log_test.bal
+++ b/ballerina/tests/log_test.bal
@@ -14,24 +14,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/io;
 import ballerina/jballerina.java;
 import ballerina/test;
 
 string logMessage = "";
 
 @test:Mock {
-    moduleName: "ballerina/log",
-    functionName: "println"
+    moduleName: "ballerina/io",
+    functionName: "fprintln"
 }
-test:MockFunction mock_println = new ();
+test:MockFunction mock_fprintln = new ();
 
-function mockPrintln(handle receiver, handle msg) {
+function mockFprintln(io:FileOutputStream fileOutputStream, io:Printable... values) {
     logMessage = "something went wrong";
 }
 
 @test:Config {}
 function testPrintLog() {
-    test:when(mock_println).call("mockPrintln");
+    test:when(mock_fprintln).call("mockFprintln");
 
     main();
     test:assertEquals(logMessage, "something went wrong");

--- a/integration-tests/Dependencies.toml
+++ b/integration-tests/Dependencies.toml
@@ -8,6 +8,22 @@ dependencies-toml-version = "2"
 
 [[package]]
 org = "ballerina"
+name = "integration_tests"
+version = "2.0.0"
+transitive = false
+dependencies = [
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.value"},
+	{org = "ballerina", name = "regex"},
+	{org = "ballerina", name = "test"}
+]
+modules = [
+	{org = "ballerina", packageName = "integration_tests", moduleName = "integration_tests"}
+]
+
+[[package]]
+org = "ballerina"
 name = "io"
 version = "1.0.0"
 scope = "testOnly"

--- a/integration-tests/tests/resources/samples/print-functions/debug.bal
+++ b/integration-tests/tests/resources/samples/print-functions/debug.bal
@@ -16,6 +16,8 @@
 
 import ballerina/log;
 
+type HttpError error<map<anydata>>;
+
 public function main() {
     error e = error("bad sad");
     log:printDebug("debug log");
@@ -25,6 +27,13 @@ public function main() {
     log:printDebug("debug log", 'error = e, username = "Alex92", id = 845315, foo = true);
     log:printDebug("debug log\t\n\r\\\"", username = "Alex92\t\n\r\\\"");
     f1();
+
+    map<anydata> httpError = {
+        "code": 403,
+        "details": "Authentication failed"
+    };
+    HttpError err = error(httpError.toJsonString());
+    log:printDebug("debug log", 'error = err);
 }
 
 function f1() {

--- a/integration-tests/tests/resources/samples/print-functions/error.bal
+++ b/integration-tests/tests/resources/samples/print-functions/error.bal
@@ -16,6 +16,8 @@
 
 import ballerina/log;
 
+type HttpError error<map<anydata>>;
+
 public function main() {
     error e = error("bad sad");
     log:printError("error log");
@@ -25,6 +27,13 @@ public function main() {
     log:printError("error log", 'error = e, username = "Alex92", id = 845315, foo = true);
     log:printError("error log\t\n\r\\\"", username = "Alex92\t\n\r\\\"");
     f1();
+
+    map<anydata> httpError = {
+        "code": 403,
+        "details": "Authentication failed"
+    };
+    HttpError err = error(httpError.toJsonString());
+    log:printError("error log", 'error = err);
 }
 
 function f1() {

--- a/integration-tests/tests/resources/samples/print-functions/info.bal
+++ b/integration-tests/tests/resources/samples/print-functions/info.bal
@@ -16,6 +16,8 @@
 
 import ballerina/log;
 
+type HttpError error<map<anydata>>;
+
 public function main() {
     error e = error("bad sad");
     log:printInfo("info log");
@@ -25,6 +27,13 @@ public function main() {
     log:printInfo("info log", 'error = e, username = "Alex92", id = 845315, foo = true);
     log:printInfo("info log\t\n\r\\\"", username = "Alex92\t\n\r\\\"");
     f1();
+
+    map<anydata> httpError = {
+        "code": 403,
+        "details": "Authentication failed"
+    };
+    HttpError err = error(httpError.toJsonString());
+    log:printInfo("info log", 'error = err);
 }
 
 function f1() {

--- a/integration-tests/tests/resources/samples/print-functions/warn.bal
+++ b/integration-tests/tests/resources/samples/print-functions/warn.bal
@@ -16,6 +16,8 @@
 
 import ballerina/log;
 
+type HttpError error<map<anydata>>;
+
 public function main() {
     error e = error("bad sad");
     log:printWarn("warn log");
@@ -25,6 +27,13 @@ public function main() {
     log:printWarn("warn log", 'error = e, username = "Alex92", id = 845315, foo = true);
     log:printWarn("warn log\t\n\r\\\"", username = "Alex92\t\n\r\\\"");
     f1();
+
+    map<anydata> httpError = {
+        "code": 403,
+        "details": "Authentication failed"
+    };
+    HttpError err = error(httpError.toJsonString());
+    log:printWarn("warn log", 'error = err);
 }
 
 function f1() {

--- a/integration-tests/tests/tests_json.bal
+++ b/integration-tests/tests/tests_json.bal
@@ -69,14 +69,15 @@ public function testPrintDebugJson() {
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = checkpanic sc.read(100000);
     string[] logLines = regex:split(outText, "\n");
-    test:assertEquals(logLines.length(), 12, INCORRECT_NUMBER_OF_LINES);
+    test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\"}");
     validateLogJson(logLines[6], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[7], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"username\":\"Alex92\", \"id\":845315}");
     validateLogJson(logLines[8], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"error\":\"bad sad\"}");
     validateLogJson(logLines[9], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"error\":\"bad sad\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[10], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\\t\\n\\r\\\\\\\"\", \"username\":\"Alex92\\t\\n\\r\\\\\\\"\"}");
-    validateLogJson(logLines[11], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"stackTrace\":[{\"callableName\":\"f3\", \"fileName\":\"debug.bal\", \"lineNumber\":39}, {\"callableName\":\"f2\", \"fileName\":\"debug.bal\", \"lineNumber\":35}, {\"callableName\":\"f1\", \"fileName\":\"debug.bal\", \"lineNumber\":31}, {\"callableName\":\"main\", \"fileName\":\"debug.bal\", \"lineNumber\":27}], \"username\":\"Alex92\", \"id\":845315}");
+    validateLogJson(logLines[11], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"stackTrace\":[{\"callableName\":\"f3\", \"fileName\":\"debug.bal\", \"lineNumber\":48}, {\"callableName\":\"f2\", \"fileName\":\"debug.bal\", \"lineNumber\":44}, {\"callableName\":\"f1\", \"fileName\":\"debug.bal\", \"lineNumber\":40}, {\"callableName\":\"main\", \"fileName\":\"debug.bal\", \"lineNumber\":29}], \"username\":\"Alex92\", \"id\":845315}");
+    validateLogJson(logLines[12], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
 }
 
 @test:Config {}
@@ -89,14 +90,15 @@ public function testPrintErrorJson() {
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = checkpanic sc.read(100000);
     string[] logLines = regex:split(outText, "\n");
-    test:assertEquals(logLines.length(), 12, INCORRECT_NUMBER_OF_LINES);
+    test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\"}");
     validateLogJson(logLines[6], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[7], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"username\":\"Alex92\", \"id\":845315}");
     validateLogJson(logLines[8], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"error\":\"bad sad\"}");
     validateLogJson(logLines[9], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"error\":\"bad sad\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[10], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\\t\\n\\r\\\\\\\"\", \"username\":\"Alex92\\t\\n\\r\\\\\\\"\"}");
-    validateLogJson(logLines[11], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"stackTrace\":[{\"callableName\":\"f3\", \"fileName\":\"error.bal\", \"lineNumber\":39}, {\"callableName\":\"f2\", \"fileName\":\"error.bal\", \"lineNumber\":35}, {\"callableName\":\"f1\", \"fileName\":\"error.bal\", \"lineNumber\":31}, {\"callableName\":\"main\", \"fileName\":\"error.bal\", \"lineNumber\":27}], \"username\":\"Alex92\", \"id\":845315}");
+    validateLogJson(logLines[11], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"stackTrace\":[{\"callableName\":\"f3\", \"fileName\":\"error.bal\", \"lineNumber\":48}, {\"callableName\":\"f2\", \"fileName\":\"error.bal\", \"lineNumber\":44}, {\"callableName\":\"f1\", \"fileName\":\"error.bal\", \"lineNumber\":40}, {\"callableName\":\"main\", \"fileName\":\"error.bal\", \"lineNumber\":29}], \"username\":\"Alex92\", \"id\":845315}");
+    validateLogJson(logLines[12], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
 }
 
 @test:Config {}
@@ -109,14 +111,15 @@ public function testPrintInfoJson() {
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = checkpanic sc.read(100000);
     string[] logLines = regex:split(outText, "\n");
-    test:assertEquals(logLines.length(), 12, INCORRECT_NUMBER_OF_LINES);
+    test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\"}");
     validateLogJson(logLines[6], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[7], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"username\":\"Alex92\", \"id\":845315}");
     validateLogJson(logLines[8], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"error\":\"bad sad\"}");
     validateLogJson(logLines[9], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"error\":\"bad sad\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[10], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\\t\\n\\r\\\\\\\"\", \"username\":\"Alex92\\t\\n\\r\\\\\\\"\"}");
-    validateLogJson(logLines[11], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"stackTrace\":[{\"callableName\":\"f3\", \"fileName\":\"info.bal\", \"lineNumber\":39}, {\"callableName\":\"f2\", \"fileName\":\"info.bal\", \"lineNumber\":35}, {\"callableName\":\"f1\", \"fileName\":\"info.bal\", \"lineNumber\":31}, {\"callableName\":\"main\", \"fileName\":\"info.bal\", \"lineNumber\":27}], \"username\":\"Alex92\", \"id\":845315}");
+    validateLogJson(logLines[11], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"stackTrace\":[{\"callableName\":\"f3\", \"fileName\":\"info.bal\", \"lineNumber\":48}, {\"callableName\":\"f2\", \"fileName\":\"info.bal\", \"lineNumber\":44}, {\"callableName\":\"f1\", \"fileName\":\"info.bal\", \"lineNumber\":40}, {\"callableName\":\"main\", \"fileName\":\"info.bal\", \"lineNumber\":29}], \"username\":\"Alex92\", \"id\":845315}");
+    validateLogJson(logLines[12], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
 }
 
 @test:Config {}
@@ -129,14 +132,15 @@ public function testPrintWarnJson() {
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = checkpanic sc.read(100000);
     string[] logLines = regex:split(outText, "\n");
-    test:assertEquals(logLines.length(), 12, INCORRECT_NUMBER_OF_LINES);
+    test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\"}");
     validateLogJson(logLines[6], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[7], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"username\":\"Alex92\", \"id\":845315}");
     validateLogJson(logLines[8], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"error\":\"bad sad\"}");
     validateLogJson(logLines[9], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"error\":\"bad sad\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[10], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\\t\\n\\r\\\\\\\"\", \"username\":\"Alex92\\t\\n\\r\\\\\\\"\"}");
-    validateLogJson(logLines[11], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"stackTrace\":[{\"callableName\":\"f3\", \"fileName\":\"warn.bal\", \"lineNumber\":39}, {\"callableName\":\"f2\", \"fileName\":\"warn.bal\", \"lineNumber\":35}, {\"callableName\":\"f1\", \"fileName\":\"warn.bal\", \"lineNumber\":31}, {\"callableName\":\"main\", \"fileName\":\"warn.bal\", \"lineNumber\":27}], \"username\":\"Alex92\", \"id\":845315}");
+    validateLogJson(logLines[11], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"stackTrace\":[{\"callableName\":\"f3\", \"fileName\":\"warn.bal\", \"lineNumber\":48}, {\"callableName\":\"f2\", \"fileName\":\"warn.bal\", \"lineNumber\":44}, {\"callableName\":\"f1\", \"fileName\":\"warn.bal\", \"lineNumber\":40}, {\"callableName\":\"main\", \"fileName\":\"warn.bal\", \"lineNumber\":29}], \"username\":\"Alex92\", \"id\":845315}");
+    validateLogJson(logLines[12], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
 }
 
 @test:Config {}

--- a/integration-tests/tests/tests_logfmt.bal
+++ b/integration-tests/tests/tests_logfmt.bal
@@ -80,14 +80,15 @@ public function testPrintDebugLogfmt() {
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = checkpanic sc.read(100000);
     string[] logLines = regex:split(outText, "\n");
-    test:assertEquals(logLines.length(), 12, INCORRECT_NUMBER_OF_LINES);
+    test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], " level = DEBUG module = \"\" message = \"debug log\"");
     validateLog(logLines[6], " level = DEBUG module = \"\" message = \"debug log\" username = \"Alex92\" id = 845315 foo = true");
     validateLog(logLines[7], " level = DEBUG module = \"\" message = \"debug log\" username = \"Alex92\" id = 845315");
     validateLog(logLines[8], " level = DEBUG module = \"\" message = \"debug log\" error = \"bad sad\"");
     validateLog(logLines[9], " level = DEBUG module = \"\" message = \"debug log\" error = \"bad sad\" username = \"Alex92\" id = 845315 foo = true");
     validateLog(logLines[10], " level = DEBUG module = \"\" message = \"debug log\\t\\n\\r\\\\\\\"\" username = \"Alex92\\t\\n\\r\\\\\\\"\"");
-    validateLog(logLines[11], " level = DEBUG module = \"\" message = \"debug log\" stackTrace = [{\"callableName\":\"f3\",\"fileName\":\"debug.bal\",\"lineNumber\":39},{\"callableName\":\"f2\",\"fileName\":\"debug.bal\",\"lineNumber\":35},{\"callableName\":\"f1\",\"fileName\":\"debug.bal\",\"lineNumber\":31},{\"callableName\":\"main\",\"fileName\":\"debug.bal\",\"lineNumber\":27}] username = \"Alex92\" id = 845315");
+    validateLog(logLines[11], " level = DEBUG module = \"\" message = \"debug log\" stackTrace = [{\"callableName\":\"f3\",\"fileName\":\"debug.bal\",\"lineNumber\":48},{\"callableName\":\"f2\",\"fileName\":\"debug.bal\",\"lineNumber\":44},{\"callableName\":\"f1\",\"fileName\":\"debug.bal\",\"lineNumber\":40},{\"callableName\":\"main\",\"fileName\":\"debug.bal\",\"lineNumber\":29}] username = \"Alex92\" id = 845315");
+    validateLog(logLines[12], " level = DEBUG module = \"\" message = \"debug log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
 }
 
 @test:Config {}
@@ -100,14 +101,15 @@ public function testPrintErrorLogfmt() {
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = checkpanic sc.read(100000);
     string[] logLines = regex:split(outText, "\n");
-    test:assertEquals(logLines.length(), 12, INCORRECT_NUMBER_OF_LINES);
+    test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], " level = ERROR module = \"\" message = \"error log\"");
     validateLog(logLines[6], " level = ERROR module = \"\" message = \"error log\" username = \"Alex92\" id = 845315 foo = true");
     validateLog(logLines[7], " level = ERROR module = \"\" message = \"error log\" username = \"Alex92\" id = 845315");
     validateLog(logLines[8], " level = ERROR module = \"\" message = \"error log\" error = \"bad sad\"");
     validateLog(logLines[9], " level = ERROR module = \"\" message = \"error log\" error = \"bad sad\" username = \"Alex92\" id = 845315 foo = true");
     validateLog(logLines[10], " level = ERROR module = \"\" message = \"error log\\t\\n\\r\\\\\\\"\" username = \"Alex92\\t\\n\\r\\\\\\\"\"");
-    validateLog(logLines[11], " level = ERROR module = \"\" message = \"error log\" stackTrace = [{\"callableName\":\"f3\",\"fileName\":\"error.bal\",\"lineNumber\":39},{\"callableName\":\"f2\",\"fileName\":\"error.bal\",\"lineNumber\":35},{\"callableName\":\"f1\",\"fileName\":\"error.bal\",\"lineNumber\":31},{\"callableName\":\"main\",\"fileName\":\"error.bal\",\"lineNumber\":27}] username = \"Alex92\" id = 845315");
+    validateLog(logLines[11], " level = ERROR module = \"\" message = \"error log\" stackTrace = [{\"callableName\":\"f3\",\"fileName\":\"error.bal\",\"lineNumber\":48},{\"callableName\":\"f2\",\"fileName\":\"error.bal\",\"lineNumber\":44},{\"callableName\":\"f1\",\"fileName\":\"error.bal\",\"lineNumber\":40},{\"callableName\":\"main\",\"fileName\":\"error.bal\",\"lineNumber\":29}] username = \"Alex92\" id = 845315");
+    validateLog(logLines[12], " level = ERROR module = \"\" message = \"error log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
 }
 
 @test:Config {}
@@ -120,14 +122,15 @@ public function testPrintInfoLogfmt() {
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = checkpanic sc.read(100000);
     string[] logLines = regex:split(outText, "\n");
-    test:assertEquals(logLines.length(), 12, INCORRECT_NUMBER_OF_LINES);
+    test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], " level = INFO module = \"\" message = \"info log\"");
     validateLog(logLines[6], " level = INFO module = \"\" message = \"info log\" username = \"Alex92\" id = 845315 foo = true");
     validateLog(logLines[7], " level = INFO module = \"\" message = \"info log\" username = \"Alex92\" id = 845315");
     validateLog(logLines[8], " level = INFO module = \"\" message = \"info log\" error = \"bad sad\"");
     validateLog(logLines[9], " level = INFO module = \"\" message = \"info log\" error = \"bad sad\" username = \"Alex92\" id = 845315 foo = true");
     validateLog(logLines[10], " level = INFO module = \"\" message = \"info log\\t\\n\\r\\\\\\\"\" username = \"Alex92\\t\\n\\r\\\\\\\"\"");
-    validateLog(logLines[11], " level = INFO module = \"\" message = \"info log\" stackTrace = [{\"callableName\":\"f3\",\"fileName\":\"info.bal\",\"lineNumber\":39},{\"callableName\":\"f2\",\"fileName\":\"info.bal\",\"lineNumber\":35},{\"callableName\":\"f1\",\"fileName\":\"info.bal\",\"lineNumber\":31},{\"callableName\":\"main\",\"fileName\":\"info.bal\",\"lineNumber\":27}] username = \"Alex92\" id = 845315");
+    validateLog(logLines[11], " level = INFO module = \"\" message = \"info log\" stackTrace = [{\"callableName\":\"f3\",\"fileName\":\"info.bal\",\"lineNumber\":48},{\"callableName\":\"f2\",\"fileName\":\"info.bal\",\"lineNumber\":44},{\"callableName\":\"f1\",\"fileName\":\"info.bal\",\"lineNumber\":40},{\"callableName\":\"main\",\"fileName\":\"info.bal\",\"lineNumber\":29}] username = \"Alex92\" id = 845315");
+    validateLog(logLines[12], " level = INFO module = \"\" message = \"info log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
 }
 
 @test:Config {}
@@ -140,14 +143,15 @@ public function testPrintWarnLogfmt() {
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = checkpanic sc.read(100000);
     string[] logLines = regex:split(outText, "\n");
-    test:assertEquals(logLines.length(), 12, INCORRECT_NUMBER_OF_LINES);
+    test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], " level = WARN module = \"\" message = \"warn log\"");
     validateLog(logLines[6], " level = WARN module = \"\" message = \"warn log\" username = \"Alex92\" id = 845315 foo = true");
     validateLog(logLines[7], " level = WARN module = \"\" message = \"warn log\" username = \"Alex92\" id = 845315");
     validateLog(logLines[8], " level = WARN module = \"\" message = \"warn log\" error = \"bad sad\"");
     validateLog(logLines[9], " level = WARN module = \"\" message = \"warn log\" error = \"bad sad\" username = \"Alex92\" id = 845315 foo = true");
     validateLog(logLines[10], " level = WARN module = \"\" message = \"warn log\\t\\n\\r\\\\\\\"\" username = \"Alex92\\t\\n\\r\\\\\\\"\"");
-    validateLog(logLines[11], " level = WARN module = \"\" message = \"warn log\" stackTrace = [{\"callableName\":\"f3\",\"fileName\":\"warn.bal\",\"lineNumber\":39},{\"callableName\":\"f2\",\"fileName\":\"warn.bal\",\"lineNumber\":35},{\"callableName\":\"f1\",\"fileName\":\"warn.bal\",\"lineNumber\":31},{\"callableName\":\"main\",\"fileName\":\"warn.bal\",\"lineNumber\":27}] username = \"Alex92\" id = 845315");
+    validateLog(logLines[11], " level = WARN module = \"\" message = \"warn log\" stackTrace = [{\"callableName\":\"f3\",\"fileName\":\"warn.bal\",\"lineNumber\":48},{\"callableName\":\"f2\",\"fileName\":\"warn.bal\",\"lineNumber\":44},{\"callableName\":\"f1\",\"fileName\":\"warn.bal\",\"lineNumber\":40},{\"callableName\":\"main\",\"fileName\":\"warn.bal\",\"lineNumber\":29}] username = \"Alex92\" id = 845315");
+    validateLog(logLines[12], " level = WARN module = \"\" message = \"warn log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
 }
 
 @test:Config {}


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1959

Users can pass 2 types of errors; `string` type errors and `json` type errors. Log module will escape the `string` type error but will not escape the `json` type error.

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests