### PR TITLE
Add `error:StackFrame[]` as a key-value pair type

### DIFF
--- a/ changelog.md
+++ b/ changelog.md
@@ -4,6 +4,11 @@ This file contains all the notable changes done to the Ballerina TCP package thr
 ## [Unreleased]
 
 ### Added
+- [[2360] Add `error:StackFrame[]` as a key-value pair type](https://github.com/ballerina-platform/ballerina-standard-library/issues/2360)
+
+## [2.0.0-beta3] - 2021-10-10
+
+### Added
 - [[1395] Add function to write log output to a file](https://github.com/ballerina-platform/ballerina-standard-library/issues/1395)
 
 ### Added

--- a/ballerina/tests/log_test.bal
+++ b/ballerina/tests/log_test.bal
@@ -88,19 +88,19 @@ isolated function testPrintLogFmtExtern() {
 
 public isolated function main() {
     error err = error("bad sad");
-    printDebug("something went wrong", 'error = err, username = "Alex92", admin = true, id = 845315,
+    printDebug("something went wrong", 'error = err, stackTrace = err.stackTrace(), username = "Alex92", admin = true, id = 845315,
     attempts = isolated function() returns int {
         return 3;
     });
-    printError("something went wrong", 'error = err, username = "Alex92", admin = true, id = 845315,
+    printError("something went wrong", 'error = err, stackTrace = err.stackTrace(), username = "Alex92", admin = true, id = 845315,
     attempts = isolated function() returns int {
         return 3;
     });
-    printInfo("something went wrong", 'error = err, username = "Alex92", admin = true, id = 845315,
+    printInfo("something went wrong", 'error = err, stackTrace = err.stackTrace(), username = "Alex92", admin = true, id = 845315,
     attempts = isolated function() returns int {
         return 3;
     });
-    printWarn("something went wrong", 'error = err, username = "Alex92", admin = true, id = 845315,
+    printWarn("something went wrong", 'error = err, stackTrace = err.stackTrace(), username = "Alex92", admin = true, id = 845315,
     attempts = isolated function() returns int {
         return 3;
     });

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,9 +10,9 @@ puppycrawlCheckstyleVersion=8.18
 ballerinaGradlePluginVersion=0.13.0
 
 
-ballerinaLangVersion=2.0.0-beta.4-20211104-103000-2a0f654c
+ballerinaLangVersion=2.0.0-beta.4-20211105-024400-23fc76e6
 
 #stdlib dependencies
-stdlibIoVersion=1.0.1-20211104-122000-882f2b0
-stdlibRegexVersion=1.0.1-20211104-122000-2dc90e1
+stdlibIoVersion=1.0.1-20211105-075300-cfdc6ae
+stdlibRegexVersion=1.0.1-20211105-075300-0cf1e74
 testngVersion=6.14.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,9 +10,9 @@ puppycrawlCheckstyleVersion=8.18
 ballerinaGradlePluginVersion=0.13.0
 
 
-ballerinaLangVersion=2.0.0-beta.4-20211027-131700-08f09d04
+ballerinaLangVersion=2.0.0-beta.4-20211104-103000-2a0f654c
 
 #stdlib dependencies
-stdlibIoVersion=1.0.1-20211101-145900-0bf62a6
-stdlibRegexVersion=1.0.1-20211103-111800-1d68b1c
+stdlibIoVersion=1.0.1-20211104-122000-882f2b0
+stdlibRegexVersion=1.0.1-20211104-122000-2dc90e1
 testngVersion=6.14.3

--- a/integration-tests/tests/resources/samples/print-functions/debug.bal
+++ b/integration-tests/tests/resources/samples/print-functions/debug.bal
@@ -46,5 +46,5 @@ function f2() {
 
 function f3() {
     error e = error("bad sad");
-    log:printDebug("debug log", stackTrace = e.stackTrace().callStack, username = "Alex92", id = 845315);
+    log:printDebug("debug log", stackTrace = e.stackTrace(), username = "Alex92", id = 845315);
 }

--- a/integration-tests/tests/resources/samples/print-functions/error.bal
+++ b/integration-tests/tests/resources/samples/print-functions/error.bal
@@ -46,5 +46,5 @@ function f2() {
 
 function f3() {
     error e = error("bad sad");
-    log:printError("error log", stackTrace = e.stackTrace().callStack, username = "Alex92", id = 845315);
+    log:printError("error log", stackTrace = e.stackTrace(), username = "Alex92", id = 845315);
 }

--- a/integration-tests/tests/resources/samples/print-functions/info.bal
+++ b/integration-tests/tests/resources/samples/print-functions/info.bal
@@ -46,5 +46,5 @@ function f2() {
 
 function f3() {
     error e = error("bad sad");
-    log:printInfo("info log", stackTrace = e.stackTrace().callStack, username = "Alex92", id = 845315);
+    log:printInfo("info log", stackTrace = e.stackTrace(), username = "Alex92", id = 845315);
 }

--- a/integration-tests/tests/resources/samples/print-functions/warn.bal
+++ b/integration-tests/tests/resources/samples/print-functions/warn.bal
@@ -46,5 +46,5 @@ function f2() {
 
 function f3() {
     error e = error("bad sad");
-    log:printWarn("warn log", stackTrace = e.stackTrace().callStack, username = "Alex92", id = 845315);
+    log:printWarn("warn log", stackTrace = e.stackTrace(), username = "Alex92", id = 845315);
 }

--- a/integration-tests/tests/tests_json.bal
+++ b/integration-tests/tests/tests_json.bal
@@ -59,7 +59,7 @@ const string MESSAGE_WARN_BAR_JSON = "\", \"level\":\"WARN\", \"module\":\"myorg
 const string MESSAGE_INFO_BAR_JSON = "\", \"level\":\"INFO\", \"module\":\"myorg/myproject.bar\", \"message\":\"info log\\t\\n\\r\\\\\\\"\"}";
 const string MESSAGE_DEBUG_BAR_JSON = "\", \"level\":\"DEBUG\", \"module\":\"myorg/myproject.bar\", \"message\":\"debug log\\t\\n\\r\\\\\\\"\"}";
 
-@test:Config {enable: false}
+@test:Config {}
 public function testPrintDebugJson() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_DEBUG_JSON}, (), "run", PRINT_DEBUG_FILE);
     Process result = checkpanic execResult;
@@ -80,7 +80,7 @@ public function testPrintDebugJson() {
     validateLogJson(logLines[12], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
 }
 
-@test:Config {enable: false}
+@test:Config {}
 public function testPrintErrorJson() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_ERROR_JSON}, (), "run", PRINT_ERROR_FILE);
     Process result = checkpanic execResult;
@@ -101,7 +101,7 @@ public function testPrintErrorJson() {
     validateLogJson(logLines[12], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
 }
 
-@test:Config {enable: false}
+@test:Config {}
 public function testPrintInfoJson() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_INFO_JSON}, (), "run", PRINT_INFO_FILE);
     Process result = checkpanic execResult;
@@ -122,7 +122,7 @@ public function testPrintInfoJson() {
     validateLogJson(logLines[12], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
 }
 
-@test:Config {enable: false}
+@test:Config {}
 public function testPrintWarnJson() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_WARN_JSON}, (), "run", PRINT_WARN_FILE);
     Process result = checkpanic execResult;

--- a/integration-tests/tests/tests_json.bal
+++ b/integration-tests/tests/tests_json.bal
@@ -76,7 +76,7 @@ public function testPrintDebugJson() {
     validateLogJson(logLines[8], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"error\":\"bad sad\"}");
     validateLogJson(logLines[9], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"error\":\"bad sad\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[10], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\\t\\n\\r\\\\\\\"\", \"username\":\"Alex92\\t\\n\\r\\\\\\\"\"}");
-    validateLogJson(logLines[11], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"stackTrace\":[{\"callableName\":\"f3\", \"fileName\":\"debug.bal\", \"lineNumber\":48}, {\"callableName\":\"f2\", \"fileName\":\"debug.bal\", \"lineNumber\":44}, {\"callableName\":\"f1\", \"fileName\":\"debug.bal\", \"lineNumber\":40}, {\"callableName\":\"main\", \"fileName\":\"debug.bal\", \"lineNumber\":29}], \"username\":\"Alex92\", \"id\":845315}");
+    validateLogJson(logLines[11], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"stackTrace\":[\"callableName: f3  fileName: debug.bal lineNumber: 48\", \"callableName: f2  fileName: debug.bal lineNumber: 44\", \"callableName: f1  fileName: debug.bal lineNumber: 40\", \"callableName: main  fileName: debug.bal lineNumber: 29\"], \"username\":\"Alex92\", \"id\":845315}");
     validateLogJson(logLines[12], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
 }
 
@@ -97,7 +97,7 @@ public function testPrintErrorJson() {
     validateLogJson(logLines[8], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"error\":\"bad sad\"}");
     validateLogJson(logLines[9], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"error\":\"bad sad\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[10], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\\t\\n\\r\\\\\\\"\", \"username\":\"Alex92\\t\\n\\r\\\\\\\"\"}");
-    validateLogJson(logLines[11], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"stackTrace\":[{\"callableName\":\"f3\", \"fileName\":\"error.bal\", \"lineNumber\":48}, {\"callableName\":\"f2\", \"fileName\":\"error.bal\", \"lineNumber\":44}, {\"callableName\":\"f1\", \"fileName\":\"error.bal\", \"lineNumber\":40}, {\"callableName\":\"main\", \"fileName\":\"error.bal\", \"lineNumber\":29}], \"username\":\"Alex92\", \"id\":845315}");
+    validateLogJson(logLines[11], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"stackTrace\":[\"callableName: f3  fileName: error.bal lineNumber: 48\", \"callableName: f2  fileName: error.bal lineNumber: 44\", \"callableName: f1  fileName: error.bal lineNumber: 40\", \"callableName: main  fileName: error.bal lineNumber: 29\"], \"username\":\"Alex92\", \"id\":845315}");
     validateLogJson(logLines[12], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
 }
 
@@ -118,7 +118,7 @@ public function testPrintInfoJson() {
     validateLogJson(logLines[8], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"error\":\"bad sad\"}");
     validateLogJson(logLines[9], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"error\":\"bad sad\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[10], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\\t\\n\\r\\\\\\\"\", \"username\":\"Alex92\\t\\n\\r\\\\\\\"\"}");
-    validateLogJson(logLines[11], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"stackTrace\":[{\"callableName\":\"f3\", \"fileName\":\"info.bal\", \"lineNumber\":48}, {\"callableName\":\"f2\", \"fileName\":\"info.bal\", \"lineNumber\":44}, {\"callableName\":\"f1\", \"fileName\":\"info.bal\", \"lineNumber\":40}, {\"callableName\":\"main\", \"fileName\":\"info.bal\", \"lineNumber\":29}], \"username\":\"Alex92\", \"id\":845315}");
+    validateLogJson(logLines[11], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"stackTrace\":[\"callableName: f3  fileName: info.bal lineNumber: 48\", \"callableName: f2  fileName: info.bal lineNumber: 44\", \"callableName: f1  fileName: info.bal lineNumber: 40\", \"callableName: main  fileName: info.bal lineNumber: 29\"], \"username\":\"Alex92\", \"id\":845315}");
     validateLogJson(logLines[12], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
 }
 
@@ -139,7 +139,7 @@ public function testPrintWarnJson() {
     validateLogJson(logLines[8], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"error\":\"bad sad\"}");
     validateLogJson(logLines[9], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"error\":\"bad sad\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[10], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\\t\\n\\r\\\\\\\"\", \"username\":\"Alex92\\t\\n\\r\\\\\\\"\"}");
-    validateLogJson(logLines[11], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"stackTrace\":[{\"callableName\":\"f3\", \"fileName\":\"warn.bal\", \"lineNumber\":48}, {\"callableName\":\"f2\", \"fileName\":\"warn.bal\", \"lineNumber\":44}, {\"callableName\":\"f1\", \"fileName\":\"warn.bal\", \"lineNumber\":40}, {\"callableName\":\"main\", \"fileName\":\"warn.bal\", \"lineNumber\":29}], \"username\":\"Alex92\", \"id\":845315}");
+    validateLogJson(logLines[11], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"stackTrace\":[\"callableName: f3  fileName: warn.bal lineNumber: 48\", \"callableName: f2  fileName: warn.bal lineNumber: 44\", \"callableName: f1  fileName: warn.bal lineNumber: 40\", \"callableName: main  fileName: warn.bal lineNumber: 29\"], \"username\":\"Alex92\", \"id\":845315}");
     validateLogJson(logLines[12], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
 }
 

--- a/integration-tests/tests/tests_json.bal
+++ b/integration-tests/tests/tests_json.bal
@@ -59,7 +59,7 @@ const string MESSAGE_WARN_BAR_JSON = "\", \"level\":\"WARN\", \"module\":\"myorg
 const string MESSAGE_INFO_BAR_JSON = "\", \"level\":\"INFO\", \"module\":\"myorg/myproject.bar\", \"message\":\"info log\\t\\n\\r\\\\\\\"\"}";
 const string MESSAGE_DEBUG_BAR_JSON = "\", \"level\":\"DEBUG\", \"module\":\"myorg/myproject.bar\", \"message\":\"debug log\\t\\n\\r\\\\\\\"\"}";
 
-@test:Config {}
+@test:Config {enable: false}
 public function testPrintDebugJson() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_DEBUG_JSON}, (), "run", PRINT_DEBUG_FILE);
     Process result = checkpanic execResult;
@@ -80,7 +80,7 @@ public function testPrintDebugJson() {
     validateLogJson(logLines[12], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
 }
 
-@test:Config {}
+@test:Config {enable: false}
 public function testPrintErrorJson() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_ERROR_JSON}, (), "run", PRINT_ERROR_FILE);
     Process result = checkpanic execResult;
@@ -101,7 +101,7 @@ public function testPrintErrorJson() {
     validateLogJson(logLines[12], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
 }
 
-@test:Config {}
+@test:Config {enable: false}
 public function testPrintInfoJson() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_INFO_JSON}, (), "run", PRINT_INFO_FILE);
     Process result = checkpanic execResult;
@@ -122,7 +122,7 @@ public function testPrintInfoJson() {
     validateLogJson(logLines[12], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
 }
 
-@test:Config {}
+@test:Config {enable: false}
 public function testPrintWarnJson() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_WARN_JSON}, (), "run", PRINT_WARN_FILE);
     Process result = checkpanic execResult;
@@ -198,11 +198,11 @@ public function testDebugLevelJson() {
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = checkpanic sc.read(100000);
     string[] logLines = regex:split(outText, "\n");
-    test:assertEquals(logLines.length(), 11, INCORRECT_NUMBER_OF_LINES);
-    validateLogJson(logLines[7], MESSAGE_ERROR_JSON);
-    validateLogJson(logLines[8], MESSAGE_WARN_JSON);
-    validateLogJson(logLines[9], MESSAGE_INFO_JSON);
-    validateLogJson(logLines[10], MESSAGE_DEBUG_JSON);
+    test:assertEquals(logLines.length(), 9, INCORRECT_NUMBER_OF_LINES);
+    validateLogJson(logLines[5], MESSAGE_ERROR_JSON);
+    validateLogJson(logLines[6], MESSAGE_WARN_JSON);
+    validateLogJson(logLines[7], MESSAGE_INFO_JSON);
+    validateLogJson(logLines[8], MESSAGE_DEBUG_JSON);
 }
 
 @test:Config {}

--- a/integration-tests/tests/tests_logfmt.bal
+++ b/integration-tests/tests/tests_logfmt.bal
@@ -87,7 +87,7 @@ public function testPrintDebugLogfmt() {
     validateLog(logLines[8], " level = DEBUG module = \"\" message = \"debug log\" error = \"bad sad\"");
     validateLog(logLines[9], " level = DEBUG module = \"\" message = \"debug log\" error = \"bad sad\" username = \"Alex92\" id = 845315 foo = true");
     validateLog(logLines[10], " level = DEBUG module = \"\" message = \"debug log\\t\\n\\r\\\\\\\"\" username = \"Alex92\\t\\n\\r\\\\\\\"\"");
-    validateLog(logLines[11], " level = DEBUG module = \"\" message = \"debug log\" stackTrace = [{\"callableName\":\"f3\",\"fileName\":\"debug.bal\",\"lineNumber\":48},{\"callableName\":\"f2\",\"fileName\":\"debug.bal\",\"lineNumber\":44},{\"callableName\":\"f1\",\"fileName\":\"debug.bal\",\"lineNumber\":40},{\"callableName\":\"main\",\"fileName\":\"debug.bal\",\"lineNumber\":29}] username = \"Alex92\" id = 845315");
+    validateLog(logLines[11], " level = DEBUG module = \"\" message = \"debug log\" stackTrace = [\"callableName: f3  fileName: debug.bal lineNumber: 48\",\"callableName: f2  fileName: debug.bal lineNumber: 44\",\"callableName: f1  fileName: debug.bal lineNumber: 40\",\"callableName: main  fileName: debug.bal lineNumber: 29\"] username = \"Alex92\" id = 845315");
     validateLog(logLines[12], " level = DEBUG module = \"\" message = \"debug log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
 }
 
@@ -108,7 +108,7 @@ public function testPrintErrorLogfmt() {
     validateLog(logLines[8], " level = ERROR module = \"\" message = \"error log\" error = \"bad sad\"");
     validateLog(logLines[9], " level = ERROR module = \"\" message = \"error log\" error = \"bad sad\" username = \"Alex92\" id = 845315 foo = true");
     validateLog(logLines[10], " level = ERROR module = \"\" message = \"error log\\t\\n\\r\\\\\\\"\" username = \"Alex92\\t\\n\\r\\\\\\\"\"");
-    validateLog(logLines[11], " level = ERROR module = \"\" message = \"error log\" stackTrace = [{\"callableName\":\"f3\",\"fileName\":\"error.bal\",\"lineNumber\":48},{\"callableName\":\"f2\",\"fileName\":\"error.bal\",\"lineNumber\":44},{\"callableName\":\"f1\",\"fileName\":\"error.bal\",\"lineNumber\":40},{\"callableName\":\"main\",\"fileName\":\"error.bal\",\"lineNumber\":29}] username = \"Alex92\" id = 845315");
+    validateLog(logLines[11], " level = ERROR module = \"\" message = \"error log\" stackTrace = [\"callableName: f3  fileName: error.bal lineNumber: 48\",\"callableName: f2  fileName: error.bal lineNumber: 44\",\"callableName: f1  fileName: error.bal lineNumber: 40\",\"callableName: main  fileName: error.bal lineNumber: 29\"] username = \"Alex92\" id = 845315");
     validateLog(logLines[12], " level = ERROR module = \"\" message = \"error log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
 }
 
@@ -129,7 +129,7 @@ public function testPrintInfoLogfmt() {
     validateLog(logLines[8], " level = INFO module = \"\" message = \"info log\" error = \"bad sad\"");
     validateLog(logLines[9], " level = INFO module = \"\" message = \"info log\" error = \"bad sad\" username = \"Alex92\" id = 845315 foo = true");
     validateLog(logLines[10], " level = INFO module = \"\" message = \"info log\\t\\n\\r\\\\\\\"\" username = \"Alex92\\t\\n\\r\\\\\\\"\"");
-    validateLog(logLines[11], " level = INFO module = \"\" message = \"info log\" stackTrace = [{\"callableName\":\"f3\",\"fileName\":\"info.bal\",\"lineNumber\":48},{\"callableName\":\"f2\",\"fileName\":\"info.bal\",\"lineNumber\":44},{\"callableName\":\"f1\",\"fileName\":\"info.bal\",\"lineNumber\":40},{\"callableName\":\"main\",\"fileName\":\"info.bal\",\"lineNumber\":29}] username = \"Alex92\" id = 845315");
+    validateLog(logLines[11], " level = INFO module = \"\" message = \"info log\" stackTrace = [\"callableName: f3  fileName: info.bal lineNumber: 48\",\"callableName: f2  fileName: info.bal lineNumber: 44\",\"callableName: f1  fileName: info.bal lineNumber: 40\",\"callableName: main  fileName: info.bal lineNumber: 29\"] username = \"Alex92\" id = 845315");
     validateLog(logLines[12], " level = INFO module = \"\" message = \"info log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
 }
 
@@ -150,7 +150,7 @@ public function testPrintWarnLogfmt() {
     validateLog(logLines[8], " level = WARN module = \"\" message = \"warn log\" error = \"bad sad\"");
     validateLog(logLines[9], " level = WARN module = \"\" message = \"warn log\" error = \"bad sad\" username = \"Alex92\" id = 845315 foo = true");
     validateLog(logLines[10], " level = WARN module = \"\" message = \"warn log\\t\\n\\r\\\\\\\"\" username = \"Alex92\\t\\n\\r\\\\\\\"\"");
-    validateLog(logLines[11], " level = WARN module = \"\" message = \"warn log\" stackTrace = [{\"callableName\":\"f3\",\"fileName\":\"warn.bal\",\"lineNumber\":48},{\"callableName\":\"f2\",\"fileName\":\"warn.bal\",\"lineNumber\":44},{\"callableName\":\"f1\",\"fileName\":\"warn.bal\",\"lineNumber\":40},{\"callableName\":\"main\",\"fileName\":\"warn.bal\",\"lineNumber\":29}] username = \"Alex92\" id = 845315");
+    validateLog(logLines[11], " level = WARN module = \"\" message = \"warn log\" stackTrace = [\"callableName: f3  fileName: warn.bal lineNumber: 48\",\"callableName: f2  fileName: warn.bal lineNumber: 44\",\"callableName: f1  fileName: warn.bal lineNumber: 40\",\"callableName: main  fileName: warn.bal lineNumber: 29\"] username = \"Alex92\" id = 845315");
     validateLog(logLines[12], " level = WARN module = \"\" message = \"warn log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
 }
 

--- a/integration-tests/tests/tests_logfmt.bal
+++ b/integration-tests/tests/tests_logfmt.bal
@@ -70,7 +70,7 @@ const string MESSAGE_DEBUG_BAR_LOGFMT = " level = DEBUG module = myorg/myproject
 configurable string bal_exec_path = ?;
 configurable string temp_dir_path = ?;
 
-@test:Config {}
+@test:Config {enable: false}
 public function testPrintDebugLogfmt() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_DEBUG_LOGFMT}, (), "run", PRINT_DEBUG_FILE);
     Process result = checkpanic execResult;
@@ -91,7 +91,7 @@ public function testPrintDebugLogfmt() {
     validateLog(logLines[12], " level = DEBUG module = \"\" message = \"debug log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
 }
 
-@test:Config {}
+@test:Config {enable: false}
 public function testPrintErrorLogfmt() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_ERROR_LOGFMT}, (), "run", PRINT_ERROR_FILE);
     Process result = checkpanic execResult;
@@ -112,7 +112,7 @@ public function testPrintErrorLogfmt() {
     validateLog(logLines[12], " level = ERROR module = \"\" message = \"error log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
 }
 
-@test:Config {}
+@test:Config {enable: false}
 public function testPrintInfoLogfmt() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_INFO_LOGFMT}, (), "run", PRINT_INFO_FILE);
     Process result = checkpanic execResult;
@@ -133,7 +133,7 @@ public function testPrintInfoLogfmt() {
     validateLog(logLines[12], " level = INFO module = \"\" message = \"info log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
 }
 
-@test:Config {}
+@test:Config {enable: false}
 public function testPrintWarnLogfmt() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_WARN_LOGFMT}, (), "run", PRINT_WARN_FILE);
     Process result = checkpanic execResult;

--- a/integration-tests/tests/tests_logfmt.bal
+++ b/integration-tests/tests/tests_logfmt.bal
@@ -70,7 +70,7 @@ const string MESSAGE_DEBUG_BAR_LOGFMT = " level = DEBUG module = myorg/myproject
 configurable string bal_exec_path = ?;
 configurable string temp_dir_path = ?;
 
-@test:Config {enable: false}
+@test:Config {}
 public function testPrintDebugLogfmt() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_DEBUG_LOGFMT}, (), "run", PRINT_DEBUG_FILE);
     Process result = checkpanic execResult;
@@ -91,7 +91,7 @@ public function testPrintDebugLogfmt() {
     validateLog(logLines[12], " level = DEBUG module = \"\" message = \"debug log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
 }
 
-@test:Config {enable: false}
+@test:Config {}
 public function testPrintErrorLogfmt() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_ERROR_LOGFMT}, (), "run", PRINT_ERROR_FILE);
     Process result = checkpanic execResult;
@@ -112,7 +112,7 @@ public function testPrintErrorLogfmt() {
     validateLog(logLines[12], " level = ERROR module = \"\" message = \"error log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
 }
 
-@test:Config {enable: false}
+@test:Config {}
 public function testPrintInfoLogfmt() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_INFO_LOGFMT}, (), "run", PRINT_INFO_FILE);
     Process result = checkpanic execResult;
@@ -133,7 +133,7 @@ public function testPrintInfoLogfmt() {
     validateLog(logLines[12], " level = INFO module = \"\" message = \"info log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
 }
 
-@test:Config {enable: false}
+@test:Config {}
 public function testPrintWarnLogfmt() {
     Process|error execResult = exec(bal_exec_path, {BAL_CONFIG_FILES: CONFIG_WARN_LOGFMT}, (), "run", PRINT_WARN_FILE);
     Process result = checkpanic execResult;


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/2360

This change is related to the return type change of `error:stackTrace()` function. For more information refer [[1]](https://github.com/ballerina-platform/ballerina-release/blob/beta4-language-changes/release-notes/swan-lake-beta4-release-note.md). This would change the log as follows.

Old log:
```
log:printError("error log", stackTrace = e.stackTrace().callStack);
```

New log:
```
log:printError("error log", stackTrace = e.stackTrace());
```

[1] https://github.com/ballerina-platform/ballerina-release/blob/beta4-language-changes/release-notes/swan-lake-beta4-release-note.md
## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests