### PR TITLE
Re-implement time generation logic in Ballerina

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "log"
-version = "2.2.0"
+version = "2.2.1"
 authors = ["Ballerina"]
 keywords = ["level", "format"]
 repository = "https://github.com/ballerina-platform/module-ballerina-log"
@@ -10,7 +10,7 @@ license = ["Apache-2.0"]
 distribution = "2201.0.0"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/log-native-2.2.0.jar"
+path = "../native/build/libs/log-native-2.2.1-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "../test-utils/build/libs/log-test-utils-2.2.0.jar"
+path = "../test-utils/build/libs/log-test-utils-2.2.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -40,7 +40,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -46,7 +46,8 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "observe"},
-	{org = "ballerina", name = "test"}
+	{org = "ballerina", name = "test"},
+	{org = "ballerina", name = "time"}
 ]
 modules = [
 	{org = "ballerina", packageName = "log", moduleName = "log"}
@@ -74,6 +75,17 @@ dependencies = [
 ]
 modules = [
 	{org = "ballerina", packageName = "test", moduleName = "test"}
+]
+
+[[package]]
+org = "ballerina"
+name = "time"
+version = "2.2.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "time", moduleName = "time"}
 ]
 
 

--- a/ballerina/tests/log_test.bal
+++ b/ballerina/tests/log_test.bal
@@ -45,7 +45,11 @@ isolated function testGetModuleName() {
 
 @test:Config {}
 isolated function testGetCurrentTime() {
-    test:assertTrue(isValidDateTime(getCurrentTime()));
+    string|error currentTime = getCurrentTime();
+    test:assertTrue(currentTime is string);
+    if currentTime is string {
+        test:assertTrue(isValidDateTime(currentTime));    
+    }
 }
 
 @test:Config {}

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ subprojects {
     dependencies {
         /* Standard libraries */
         ballerinaStdLibs "io.ballerina.stdlib:io-ballerina:${stdlibIoVersion}"
+        ballerinaStdLibs "io.ballerina.stdlib:time-ballerina:${stdlibTimeVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:regex-ballerina:${stdlibRegexVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:observe-ballerina:${observeVersion}"
         ballerinaStdLibs "io.ballerina:observe-ballerina:${observeInternalVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,7 @@ ballerinaLangVersion=2201.0.0
 
 #stdlib dependencies
 stdlibIoVersion=1.2.0
+stdlibTimeVersion=2.2.0
 stdlibRegexVersion=1.2.0
 observeVersion=1.0.1
 observeInternalVersion=1.0.1

--- a/integration-tests/Dependencies.toml
+++ b/integration-tests/Dependencies.toml
@@ -9,7 +9,7 @@ dependencies-toml-version = "2"
 [[package]]
 org = "ballerina"
 name = "integration_tests"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -74,19 +74,6 @@ task updateTomlVerions {
     }
 }
 
-task commitTomlFiles {
-    doLast {
-        project.exec {
-            ignoreExitValue true
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml"
-            } else {
-                commandLine 'sh', '-c', "git commit -m '[Automated] Update the native jar versions' Ballerina.toml Dependencies.toml"
-            }
-        }
-    }
-}
-
 task revertTomlFile {
     doLast {
         ballerinaConfigFile.text = originalBallerinaTOMLFile

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -26,6 +26,8 @@ def tomlVersion = stripBallerinaExtensionVersion("${project.version}")
 def configTOMLFile = new File("$project.projectDir/tests/Config.toml")
 def tempDir = File.createTempDir()
 def tmpDir = "build/tmp";
+def originalBallerinaTOMLFile = ballerinaConfigFile.text
+def originalConfigTOMLFile = configTOMLFile.text
 
 def stripBallerinaExtensionVersion(String extVersion) {
     if (extVersion.matches(project.ext.timestampedVersionRegex)) {
@@ -85,6 +87,13 @@ task commitTomlFiles {
     }
 }
 
+task revertTomlFile {
+    doLast {
+        ballerinaConfigFile.text = originalBallerinaTOMLFile
+        configTOMLFile.text = originalConfigTOMLFile
+    }
+}
+
 def setExecPath(configTOMLFile, distributionBinPath) {
     def distributionPath
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
@@ -133,6 +142,7 @@ task ballerinaIntegrationTests {
     dependsOn(copyTestOutputResources)
     dependsOn(":log-ballerina:build")
     dependsOn(updateTomlVerions)
+    finalizedBy(revertTomlFile)
     doLast {
         def distributionBinPath =  "$project.rootDir/target/ballerina-runtime/bin"
         setExecPath(configTOMLFile,distributionBinPath)

--- a/native/src/main/java/io/ballerina/stdlib/log/Utils.java
+++ b/native/src/main/java/io/ballerina/stdlib/log/Utils.java
@@ -22,9 +22,6 @@ import io.ballerina.runtime.api.utils.IdentifierUtils;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BString;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
 /**
  * Native function implementations of the log-api module.
  *

--- a/native/src/main/java/io/ballerina/stdlib/log/Utils.java
+++ b/native/src/main/java/io/ballerina/stdlib/log/Utils.java
@@ -50,15 +50,4 @@ public class Utils {
         }
         return StringUtils.fromString(".");
     }
-
-    /**
-     * Get the current local time.
-     *
-     * @return current local time in RFC3339 format
-     */
-    public static BString getCurrentTime() {
-        return StringUtils.fromString(
-                new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
-                        .format(new Date()));
-    }
 }

--- a/test-utils/src/main/java/io/ballerina/stdlib/log/testutils/utils/OSUtils.java
+++ b/test-utils/src/main/java/io/ballerina/stdlib/log/testutils/utils/OSUtils.java
@@ -76,6 +76,6 @@ public class OSUtils {
     }
 
     public static boolean isValidDateTime(BString dateTime) {
-        return dateTime.substring(0, 23).getValue().matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}");
+        return dateTime.substring(0, 19).getValue().matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}");
     }
 }


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/2655
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/2653
## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests

This PR will update the log output as follows.

**Old:**
```
time = 2022-02-07T14:12:33.714+05:30 level = INFO module = foo/bar message = "hello"
```

**New:**
```
time = 2022-02-07T14:12:33 level = INFO module = foo/bar message = "hello"
```