### PR TITLE
Replace slack channel link with discord server link

### DIFF
--- a/ changelog.md
+++ b/ changelog.md
@@ -6,6 +6,9 @@ This file contains all the notable changes done to the Ballerina TCP package thr
 ### Added
 - [Add code modifier support to get module name](https://github.com/ballerina-platform/ballerina-standard-library/issues/2858)
 
+### Changed
+- [API docs updated](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
+
 ## [2.4.1] - 2022-09-21
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ All contributors are encouraged to read the [Ballerina Code of Conduct](https://
 
 ## Useful links
 
-* Chat live with us via our [Slack channel](https://ballerina.io/community/slack/).
+* Chat live with us via our [Discord server](https://discord.gg/ballerinalang).
 * Post all technical questions on Stack Overflow with the [#ballerina](https://stackoverflow.com/questions/tagged/ballerina) tag.
 * For more information go to the [`log` library](https://lib.ballerina.io/ballerina/log/latest).
 * For example demonstrations of the usage, go to [Ballerina By Examples](https://ballerina.io/swan-lake/learn/by-example/).

--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -53,5 +53,5 @@ To report bugs, request new features, start new discussions, view project boards
 
 ## Useful links
 
-- Chat live with us via our [Slack channel](https://ballerina.io/community/slack/).
+- Chat live with us via our [Discord server](https://discord.gg/ballerinalang).
 - Post all technical questions on Stack Overflow with the [#ballerina](https://stackoverflow.com/questions/tagged/ballerina) tag.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -11,7 +11,7 @@ This is the specification for the Log standard library of [Ballerina language](h
 
 The Log library specification has evolved and may continue to evolve in the future. The released versions of the specification can be found under the relevant Github tag.
 
-If you have any feedback or suggestions about the library, start a discussion via a [GitHub issue](https://github.com/ballerina-platform/ballerina-standard-library/issues) or in the [Slack channel](https://ballerina.io/community/). Based on the outcome of the discussion, the specification and implementation can be updated. Community feedback is always welcome. Any accepted proposal, which affects the specification is stored under `/docs/proposals`. Proposals under discussion can be found with the label `type/proposal` in Github.
+If you have any feedback or suggestions about the library, start a discussion via a [GitHub issue](https://github.com/ballerina-platform/ballerina-standard-library/issues) or in the [Discord server](https://discord.gg/ballerinalang). Based on the outcome of the discussion, the specification and implementation can be updated. Community feedback is always welcome. Any accepted proposal, which affects the specification is stored under `/docs/proposals`. Proposals under discussion can be found with the label `type/proposal` in GitHub.
 
 The conforming implementation of the specification is released and included in the distribution. Any deviation from the specification is considered a bug.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ releasePluginVersion=2.6.0
 puppycrawlCheckstyleVersion=8.18
 ballerinaGradlePluginVersion=0.14.1
 
-ballerinaLangVersion=2201.3.0-20221009-071700-3fa663b4
+ballerinaLangVersion=2201.3.0-20221012-173100-6f66f7ec
 
 #stdlib dependencies
 stdlibIoVersion=1.3.1-20221013-104400-2228262

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,8 +12,8 @@ ballerinaGradlePluginVersion=0.14.1
 ballerinaLangVersion=2201.3.0-20221009-071700-3fa663b4
 
 #stdlib dependencies
-stdlibIoVersion=1.3.0
-stdlibRegexVersion=1.3.0
+stdlibIoVersion=1.3.1-20221013-104400-2228262
+stdlibRegexVersion=1.3.1-20221012-141600-b6ec370
 observeVersion=1.0.5
 observeInternalVersion=1.0.4
 testngVersion=6.14.3


### PR DESCRIPTION
## Purpose
https://github.com/ballerina-platform/ballerina-standard-library/issues/3463
## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
