### PR TITLE
Add error details to the log message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,12 @@ hs_err_pid*
 
 build
 .gradle/
+.vscode/
 target
+
+integration-tests/Ballerina.toml
+integration-tests/Dependencies.toml
+
 # IDEA Files
 .idea/
 *.iml

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "log"
-version = "2.8.0"
+version = "2.8.1"
 authors = ["Ballerina"]
 keywords = ["level", "format"]
 repository = "https://github.com/ballerina-platform/module-ballerina-log"
@@ -15,12 +15,12 @@ graalvmCompatible = true
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "log-native"
-version = "2.8.0"
-path = "../native/build/libs/log-native-2.8.0.jar"
+version = "2.8.1"
+path = "../native/build/libs/log-native-2.8.1-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "log-test-utils"
-version = "2.8.0"
-path = "../test-utils/build/libs/log-test-utils-2.8.0.jar"
+version = "2.8.1"
+path = "../test-utils/build/libs/log-test-utils-2.8.1-SNAPSHOT.jar"
 scope = "testOnly"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "log-compiler-plugin"
 class = "io.ballerina.stdlib.log.plugin.LogCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/log-compiler-plugin-2.8.0.jar"
+path = "../compiler-plugin/build/libs/log-compiler-plugin-2.8.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -43,18 +43,14 @@ version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
-modules = [
-	{org = "ballerina", packageName = "lang.value", moduleName = "lang.value"}
-]
 
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "observe"},
 	{org = "ballerina", name = "test"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -43,6 +43,9 @@ version = "0.0.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
+modules = [
+	{org = "ballerina", packageName = "lang.value", moduleName = "lang.value"}
+]
 
 [[package]]
 org = "ballerina"
@@ -51,6 +54,7 @@ version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.value"},
 	{org = "ballerina", name = "observe"},
 	{org = "ballerina", name = "test"}
 ]

--- a/ballerina/natives.bal
+++ b/ballerina/natives.bal
@@ -298,7 +298,7 @@ isolated function printLogFmt(LogRecord logRecord) returns string {
                 value = v.toBalString();
             }
             _ => {
-                value = v is string ? escape(v).toBalString() : v.toString();
+                value = v is string ? string `${escape(v.toString())}` : v.toString();
             }
         }
         if message == "" {
@@ -318,7 +318,7 @@ isolated function escape(string msg) returns string {
     temp = replaceString(temp, java:fromString("'"), java:fromString("\\'"));
     temp = replaceString(temp, java:fromString("\""), java:fromString("\\\""));
     string? updatedString = java:toString(temp);
-    return updatedString is string ? updatedString : msg;
+    return updatedString.toBalString();
 }
 
 isolated function replaceString(handle receiver, handle target, handle replacement) returns handle = @java:Method {

--- a/ballerina/natives.bal
+++ b/ballerina/natives.bal
@@ -16,8 +16,8 @@
 
 import ballerina/io;
 import ballerina/observe;
-import ballerina/lang.'value;
 import ballerina/jballerina.java;
+import ballerina/lang.value;
 
 # Represents log level types.
 enum LogLevel {
@@ -61,6 +61,7 @@ type LogRecord record {
     string level;
     string module;
     string message;
+    FullErrorDetails 'error?;
 };
 
 final map<int> & readonly logLevelWeight = {
@@ -176,12 +177,7 @@ isolated function print(string logLevel, string msg, error? err = (), error:Stac
         message: msg
     };
     if err is error {
-        json|error errMessage = value:fromJsonString(err.message());
-        if errMessage is json {
-            logRecord["error"] = errMessage;
-        } else {
-            logRecord["error"] = err.message();
-        }
+        logRecord.'error = getFullErrorDetails(err);
     }
     if stackTrace is error:StackFrame[] {
         json[] stackTraceArray = [];
@@ -212,6 +208,64 @@ isolated function print(string logLevel, string msg, error? err = (), error:Stac
     }
 }
 
+type StackFrame record {|
+    string callableName;
+    string? moduleName;
+    string fileName;
+    int lineNumber;
+|};
+
+type ErrorDetail record {|
+    json|string message;
+    json|string detail;
+    StackFrame[] stackTrace;
+|};
+
+type FullErrorDetails record {|
+    *ErrorDetail;
+    ErrorDetail[] causes;
+|};
+
+isolated function getFullErrorDetails(error err) returns FullErrorDetails {
+    ErrorDetail[] causes = [];
+    error? errCause = err.cause();
+
+    while errCause != () {
+        causes.push({message: parseErrorMessage(errCause.message()), stackTrace: parseStackTrace(errCause.stackTrace()), detail: parseErrorDetail(errCause.detail())});
+        errCause = errCause.cause();
+    }
+
+    return {message: parseErrorMessage(err.message()), stackTrace: parseStackTrace(err.stackTrace()), detail: parseErrorDetail(err.detail()), causes};
+}
+
+isolated function parseStackTrace(error:StackFrame[] stackTrace) returns StackFrame[] {
+    StackFrame[] stackFrames = [];
+    foreach error:StackFrame item in stackTrace {
+        java:StackFrameImpl stackFrameImpl = <java:StackFrameImpl>item;
+        StackFrame stackFrame = {
+            callableName: stackFrameImpl.callableName,
+            fileName: stackFrameImpl.fileName,
+            moduleName: stackFrameImpl.moduleName,
+            lineNumber: stackFrameImpl.lineNumber
+        };
+        stackFrames.push(stackFrame);
+    }
+    return stackFrames;
+}
+
+isolated function parseErrorMessage(string message) returns json|string {
+    json|error errMessage = value:fromJsonString(message);
+    if errMessage is json {
+        return errMessage;
+    } else {
+        return message;
+    }
+}
+
+isolated function parseErrorDetail(error:Detail detail) returns json|string {
+    return detail is anydata ? detail.toJson() : detail.toBalString();
+}
+
 isolated function fileWrite(string logOutput) {
     string output = logOutput;
     string? path = ();
@@ -240,14 +294,17 @@ isolated function printLogFmt(LogRecord logRecord) returns string {
                     value = "\"\"";
                 }
             }
+            "error" => {
+                value = v.toBalString();
+            }
             _ => {
-                value = v is string ? string `${escape(v.toString())}` : v.toString();
+                value = v is string ? escape(v).toBalString() : v.toString();
             }
         }
         if message == "" {
-            message = message + string `${k} = ${value}`;
+            message = message + string `${k}=${value}`;
         } else {
-            message = message + string ` ${k} = ${value}`;
+            message = message + string ` ${k}=${value}`;
         }
     }
     return message;
@@ -261,7 +318,7 @@ isolated function escape(string msg) returns string {
     temp = replaceString(temp, java:fromString("'"), java:fromString("\\'"));
     temp = replaceString(temp, java:fromString("\""), java:fromString("\\\""));
     string? updatedString = java:toString(temp);
-    return updatedString.toBalString();
+    return updatedString is string ? updatedString : msg;
 }
 
 isolated function replaceString(handle receiver, handle target, handle replacement) returns handle = @java:Method {

--- a/ballerina/tests/log_test.bal
+++ b/ballerina/tests/log_test.bal
@@ -52,7 +52,7 @@ isolated function testPrintLogFmtExtern() {
         message: "debug message"
     };
     test:assertEquals(printLogFmt(logRecord1),
-    "time = 2021-05-04T10:32:13.220+05:30 level = DEBUG module = foo/bar message = \"debug message\"");
+    "time=2021-05-04T10:32:13.220+05:30 level=DEBUG module=foo/bar message=\"debug message\"");
     LogRecord logRecord2 = {
         time: "2021-05-04T10:32:13.220+05:30",
         level: "INFO",
@@ -60,7 +60,7 @@ isolated function testPrintLogFmtExtern() {
         message: "debug message"
     };
     test:assertEquals(printLogFmt(logRecord2),
-    "time = 2021-05-04T10:32:13.220+05:30 level = INFO module = foo/bar message = \"debug message\"");
+    "time=2021-05-04T10:32:13.220+05:30 level=INFO module=foo/bar message=\"debug message\"");
     LogRecord logRecord3 = {
         time: "2021-05-04T10:32:13.220+05:30",
         level: "DEBUG",
@@ -68,7 +68,7 @@ isolated function testPrintLogFmtExtern() {
         message: "debug message"
     };
     test:assertEquals(printLogFmt(logRecord3),
-    "time = 2021-05-04T10:32:13.220+05:30 level = DEBUG module = \"\" message = \"debug message\"");
+    "time=2021-05-04T10:32:13.220+05:30 level=DEBUG module=\"\" message=\"debug message\"");
     LogRecord logRecord4 = {
         time: "2021-05-04T10:32:13.220+05:30",
         level: "DEBUG",
@@ -78,7 +78,7 @@ isolated function testPrintLogFmtExtern() {
         "id": 845315
     };
     test:assertEquals(printLogFmt(logRecord4),
-    "time = 2021-05-04T10:32:13.220+05:30 level = DEBUG module = foo/bar message = \"debug message\" username = \"Alex\" id = 845315");
+    "time=2021-05-04T10:32:13.220+05:30 level=DEBUG module=foo/bar message=\"debug message\" username=\"Alex\" id=845315");
 }
 
 public isolated function main() {

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -157,4 +157,8 @@ test {
 
 ballerinaIntegrationTests.dependsOn ":log-ballerina:build"
 ballerinaIntegrationTests.dependsOn updateTomlVerions
+ballerinaIntegrationTests.dependsOn compileJava
+ballerinaIntegrationTests.dependsOn jar
+ballerinaIntegrationTests.dependsOn processResources
+jar.dependsOn copyTestOutputResources
 build.dependsOn test

--- a/integration-tests/tests/resources/samples/file-write-output/output/append-logfmt.log
+++ b/integration-tests/tests/resources/samples/file-write-output/output/append-logfmt.log
@@ -1,1 +1,1 @@
-time = 2021-09-08T10:48:41.542+05:30 level = INFO module = "" message = "info log 0"
+time=2021-09-08T10:48:41.542+05:30 level=INFO module="" message="info log 0"

--- a/integration-tests/tests/resources/samples/file-write-output/output/overwrite-logfmt.log
+++ b/integration-tests/tests/resources/samples/file-write-output/output/overwrite-logfmt.log
@@ -1,1 +1,1 @@
-time = 2021-09-08T10:48:41.542+05:30 level = INFO module = "" message = "info log 0"
+time=2021-09-08T10:48:41.542+05:30 level=INFO module="" message="info log 0"

--- a/integration-tests/tests/resources/samples/file-write-output/output/project-append-logfmt.log
+++ b/integration-tests/tests/resources/samples/file-write-output/output/project-append-logfmt.log
@@ -1,1 +1,1 @@
-time = 2021-09-08T10:48:41.542+05:30 level = INFO module = "" message = "info log 0"
+time=2021-09-08T10:48:41.542+05:30 level=INFO module="" message="info log 0"

--- a/integration-tests/tests/resources/samples/file-write-output/output/project-append-logfmt2.log
+++ b/integration-tests/tests/resources/samples/file-write-output/output/project-append-logfmt2.log
@@ -1,1 +1,1 @@
-time = 2021-09-08T10:48:41.542+05:30 level = INFO module = "" message = "info log 0"
+time=2021-09-08T10:48:41.542+05:30 level=INFO module="" message="info log 0"

--- a/integration-tests/tests/resources/samples/file-write-output/output/project-overwrite-logfmt.log
+++ b/integration-tests/tests/resources/samples/file-write-output/output/project-overwrite-logfmt.log
@@ -1,1 +1,1 @@
-time = 2021-09-08T10:48:41.542+05:30 level = INFO module = "" message = "info log 0"
+time=2021-09-08T10:48:41.542+05:30 level=INFO module="" message="info log 0"

--- a/integration-tests/tests/resources/samples/file-write-output/output/project-overwrite-logfmt2.log
+++ b/integration-tests/tests/resources/samples/file-write-output/output/project-overwrite-logfmt2.log
@@ -1,1 +1,1 @@
-time = 2021-09-08T10:48:41.542+05:30 level = INFO module = "" message = "info log 0"
+time=2021-09-08T10:48:41.542+05:30 level=INFO module="" message="info log 0"

--- a/integration-tests/tests/resources/samples/observability-project-logfmt/main.bal
+++ b/integration-tests/tests/resources/samples/observability-project-logfmt/main.bal
@@ -22,7 +22,7 @@ import ballerina/observe.mockextension;
 public function main() {
     foo();
     var spans = mockextension:getFinishedSpans("Ballerina");
-    io:print("traceId = \"" + spans[0].traceId + "\" spanId = \"" + spans[0].spanId + "\"");
+    io:print("traceId=\"" + spans[0].traceId + "\" spanId=\"" + spans[0].spanId + "\"");
 }
 
 @observe:Observable

--- a/integration-tests/tests/tests_json.bal
+++ b/integration-tests/tests/tests_json.bal
@@ -72,11 +72,11 @@ public function testPrintDebugJson() returns error? {
     validateLogJson(logLines[5], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\"}");
     validateLogJson(logLines[6], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[7], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"username\":\"Alex92\", \"id\":845315}");
-    validateLogJson(logLines[8], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"error\":\"bad sad\"}");
-    validateLogJson(logLines[9], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"error\":\"bad sad\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
+    validateLogJson(logLines[8], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"error\":{\"causes\":[], \"message\":\"bad sad\", \"detail\":{}, \"stackTrace\":[{\"callableName\":\"main\", \"moduleName\":null, \"fileName\":\"debug.bal\", \"lineNumber\":22}]}}");
+    validateLogJson(logLines[9], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"error\":{\"causes\":[], \"message\":\"bad sad\", \"detail\":{}, \"stackTrace\":[{\"callableName\":\"main\", \"moduleName\":null, \"fileName\":\"debug.bal\", \"lineNumber\":22}]}, \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[10], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\\t\\n\\r\\\\\\\"\", \"username\":\"Alex92\\t\\n\\r\\\\\\\"\"}");
     validateLogJson(logLines[11], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"stackTrace\":[\"callableName: f3  fileName: debug.bal lineNumber: 48\", \"callableName: f2  fileName: debug.bal lineNumber: 44\", \"callableName: f1  fileName: debug.bal lineNumber: 40\", \"callableName: main  fileName: debug.bal lineNumber: 29\"], \"username\":\"Alex92\", \"id\":845315}");
-    validateLogJson(logLines[12], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
+    validateLogJson(logLines[12], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"error\":{\"causes\":[], \"message\":{\"code\":403, \"details\":\"Authentication failed\"}, \"detail\":{}, \"stackTrace\":[{\"callableName\":\"main\", \"moduleName\":null, \"fileName\":\"debug.bal\", \"lineNumber\":35}]}}");
 }
 
 @test:Config {}
@@ -93,11 +93,11 @@ public function testPrintErrorJson() returns error? {
     validateLogJson(logLines[5], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\"}");
     validateLogJson(logLines[6], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[7], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"username\":\"Alex92\", \"id\":845315}");
-    validateLogJson(logLines[8], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"error\":\"bad sad\"}");
-    validateLogJson(logLines[9], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"error\":\"bad sad\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
+    validateLogJson(logLines[8], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"error\":{\"causes\":[], \"message\":\"bad sad\", \"detail\":{}, \"stackTrace\":[{\"callableName\":\"main\", \"moduleName\":null, \"fileName\":\"error.bal\", \"lineNumber\":22}]}}");
+    validateLogJson(logLines[9], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"error\":{\"causes\":[], \"message\":\"bad sad\", \"detail\":{}, \"stackTrace\":[{\"callableName\":\"main\", \"moduleName\":null, \"fileName\":\"error.bal\", \"lineNumber\":22}]}, \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[10], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\\t\\n\\r\\\\\\\"\", \"username\":\"Alex92\\t\\n\\r\\\\\\\"\"}");
     validateLogJson(logLines[11], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"stackTrace\":[\"callableName: f3  fileName: error.bal lineNumber: 48\", \"callableName: f2  fileName: error.bal lineNumber: 44\", \"callableName: f1  fileName: error.bal lineNumber: 40\", \"callableName: main  fileName: error.bal lineNumber: 29\"], \"username\":\"Alex92\", \"id\":845315}");
-    validateLogJson(logLines[12], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
+    validateLogJson(logLines[12], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"error\":{\"causes\":[], \"message\":{\"code\":403, \"details\":\"Authentication failed\"}, \"detail\":{}, \"stackTrace\":[{\"callableName\":\"main\", \"moduleName\":null, \"fileName\":\"error.bal\", \"lineNumber\":35}]}}");
 }
 
 @test:Config {}
@@ -114,11 +114,11 @@ public function testPrintInfoJson() returns error? {
     validateLogJson(logLines[5], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\"}");
     validateLogJson(logLines[6], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[7], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"username\":\"Alex92\", \"id\":845315}");
-    validateLogJson(logLines[8], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"error\":\"bad sad\"}");
-    validateLogJson(logLines[9], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"error\":\"bad sad\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
+    validateLogJson(logLines[8], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"error\":{\"causes\":[], \"message\":\"bad sad\", \"detail\":{}, \"stackTrace\":[{\"callableName\":\"main\", \"moduleName\":null, \"fileName\":\"info.bal\", \"lineNumber\":22}]}}");
+    validateLogJson(logLines[9], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"error\":{\"causes\":[], \"message\":\"bad sad\", \"detail\":{}, \"stackTrace\":[{\"callableName\":\"main\", \"moduleName\":null, \"fileName\":\"info.bal\", \"lineNumber\":22}]}, \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[10], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\\t\\n\\r\\\\\\\"\", \"username\":\"Alex92\\t\\n\\r\\\\\\\"\"}");
     validateLogJson(logLines[11], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"stackTrace\":[\"callableName: f3  fileName: info.bal lineNumber: 48\", \"callableName: f2  fileName: info.bal lineNumber: 44\", \"callableName: f1  fileName: info.bal lineNumber: 40\", \"callableName: main  fileName: info.bal lineNumber: 29\"], \"username\":\"Alex92\", \"id\":845315}");
-    validateLogJson(logLines[12], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
+    validateLogJson(logLines[12], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"error\":{\"causes\":[], \"message\":{\"code\":403, \"details\":\"Authentication failed\"}, \"detail\":{}, \"stackTrace\":[{\"callableName\":\"main\", \"moduleName\":null, \"fileName\":\"info.bal\", \"lineNumber\":35}]}}");
 }
 
 @test:Config {}
@@ -135,11 +135,11 @@ public function testPrintWarnJson() returns error? {
     validateLogJson(logLines[5], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\"}");
     validateLogJson(logLines[6], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[7], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"username\":\"Alex92\", \"id\":845315}");
-    validateLogJson(logLines[8], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"error\":\"bad sad\"}");
-    validateLogJson(logLines[9], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"error\":\"bad sad\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
+    validateLogJson(logLines[8], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"error\":{\"causes\":[], \"message\":\"bad sad\", \"detail\":{}, \"stackTrace\":[{\"callableName\":\"main\", \"moduleName\":null, \"fileName\":\"warn.bal\", \"lineNumber\":22}]}}");
+    validateLogJson(logLines[9], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"error\":{\"causes\":[], \"message\":\"bad sad\", \"detail\":{}, \"stackTrace\":[{\"callableName\":\"main\", \"moduleName\":null, \"fileName\":\"warn.bal\", \"lineNumber\":22}]}, \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
     validateLogJson(logLines[10], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\\t\\n\\r\\\\\\\"\", \"username\":\"Alex92\\t\\n\\r\\\\\\\"\"}");
     validateLogJson(logLines[11], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"stackTrace\":[\"callableName: f3  fileName: warn.bal lineNumber: 48\", \"callableName: f2  fileName: warn.bal lineNumber: 44\", \"callableName: f1  fileName: warn.bal lineNumber: 40\", \"callableName: main  fileName: warn.bal lineNumber: 29\"], \"username\":\"Alex92\", \"id\":845315}");
-    validateLogJson(logLines[12], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"error\":{\"code\":403, \"details\":\"Authentication failed\"}}");
+    validateLogJson(logLines[12], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"error\":{\"causes\":[], \"message\":{\"code\":403, \"details\":\"Authentication failed\"}, \"detail\":{}, \"stackTrace\":[{\"callableName\":\"main\", \"moduleName\":null, \"fileName\":\"warn.bal\", \"lineNumber\":35}]}}");
 }
 
 @test:Config {}
@@ -457,7 +457,7 @@ public function testSetOutputFileProjectAppendJson2() returns error? {
 isolated function validateLogJson(string log, string output) {
     test:assertTrue(isValidJsonString(log), "log output is not a valid json string");
     test:assertTrue(log.includes("{\"time\":\""), "log does not contain the time");
-    test:assertTrue(log.includes(output), "log does not contain the required output");
+    test:assertTrue(log.includes(output), string `log: ${log} does not contain the output: ${output}`);
 }
 
 isolated function isValidJsonString(string log) returns boolean {

--- a/integration-tests/tests/tests_logfmt.bal
+++ b/integration-tests/tests/tests_logfmt.bal
@@ -83,14 +83,10 @@ public function testPrintDebugLogfmt() returns error? {
     validateLog(logLines[5], " level=DEBUG module=\"\" message=\"debug log\"");
     validateLog(logLines[6], " level=DEBUG module=\"\" message=\"debug log\" username=\"Alex92\" id=845315 foo=true");
     validateLog(logLines[7], " level=DEBUG module=\"\" message=\"debug log\" username=\"Alex92\" id=845315");
-    //io:println(logLines[8]);
     validateLog(logLines[8], " level=DEBUG module=\"\" message=\"debug log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"debug.bal\",\"lineNumber\":22}]}");
-    //io:println(logLines[9]);
     validateLog(logLines[9], " level=DEBUG module=\"\" message=\"debug log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"debug.bal\",\"lineNumber\":22}]} username=\"Alex92\" id=845315 foo=true");
-    //io:println(logLines[10]);
     validateLog(logLines[10], " level=DEBUG module=\"\" message=\"debug log\\t\\n\\r\\\\\\\"\" username=\"Alex92\\t\\n\\r\\\\\\\"\"");
     validateLog(logLines[11], " level=DEBUG module=\"\" message=\"debug log\" stackTrace=[\"callableName: f3  fileName: debug.bal lineNumber: 48\",\"callableName: f2  fileName: debug.bal lineNumber: 44\",\"callableName: f1  fileName: debug.bal lineNumber: 40\",\"callableName: main  fileName: debug.bal lineNumber: 29\"] username=\"Alex92\" id=845315");
-    //io:println(logLines[12]);
     validateLog(logLines[12], " level=DEBUG module=\"\" message=\"debug log\" error={\"causes\":[],\"message\":{\"code\":403,\"details\":\"Authentication failed\"},\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"debug.bal\",\"lineNumber\":35}]}");
 }
 
@@ -108,13 +104,10 @@ public function testPrintErrorLogfmt() returns error? {
     validateLog(logLines[5], " level=ERROR module=\"\" message=\"error log\"");
     validateLog(logLines[6], " level=ERROR module=\"\" message=\"error log\" username=\"Alex92\" id=845315 foo=true");
     validateLog(logLines[7], " level=ERROR module=\"\" message=\"error log\" username=\"Alex92\" id=845315");
-    //io:println(logLines[8]);
     validateLog(logLines[8], " level=ERROR module=\"\" message=\"error log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"error.bal\",\"lineNumber\":22}]}");
-    //io:println(logLines[9]);
     validateLog(logLines[9], " level=ERROR module=\"\" message=\"error log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"error.bal\",\"lineNumber\":22}]} username=\"Alex92\" id=845315 foo=true");
     validateLog(logLines[10], " level=ERROR module=\"\" message=\"error log\\t\\n\\r\\\\\\\"\" username=\"Alex92\\t\\n\\r\\\\\\\"\"");
     validateLog(logLines[11], " level=ERROR module=\"\" message=\"error log\" stackTrace=[\"callableName: f3  fileName: error.bal lineNumber: 48\",\"callableName: f2  fileName: error.bal lineNumber: 44\",\"callableName: f1  fileName: error.bal lineNumber: 40\",\"callableName: main  fileName: error.bal lineNumber: 29\"] username=\"Alex92\" id=845315");
-    //io:println(logLines[12]);
     validateLog(logLines[12], " level=ERROR module=\"\" message=\"error log\" error={\"causes\":[],\"message\":{\"code\":403,\"details\":\"Authentication failed\"},\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"error.bal\",\"lineNumber\":35}]}");
 }
 
@@ -132,13 +125,10 @@ public function testPrintInfoLogfmt() returns error? {
     validateLog(logLines[5], " level=INFO module=\"\" message=\"info log\"");
     validateLog(logLines[6], " level=INFO module=\"\" message=\"info log\" username=\"Alex92\" id=845315 foo=true");
     validateLog(logLines[7], " level=INFO module=\"\" message=\"info log\" username=\"Alex92\" id=845315");
-    //io:println(logLines[8]);
     validateLog(logLines[8], " level=INFO module=\"\" message=\"info log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"info.bal\",\"lineNumber\":22}]}");
-    //io:println(logLines[9]);
     validateLog(logLines[9], " level=INFO module=\"\" message=\"info log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"info.bal\",\"lineNumber\":22}]} username=\"Alex92\" id=845315 foo=true");
     validateLog(logLines[10], " level=INFO module=\"\" message=\"info log\\t\\n\\r\\\\\\\"\" username=\"Alex92\\t\\n\\r\\\\\\\"\"");
     validateLog(logLines[11], " level=INFO module=\"\" message=\"info log\" stackTrace=[\"callableName: f3  fileName: info.bal lineNumber: 48\",\"callableName: f2  fileName: info.bal lineNumber: 44\",\"callableName: f1  fileName: info.bal lineNumber: 40\",\"callableName: main  fileName: info.bal lineNumber: 29\"] username=\"Alex92\" id=845315");
-    //io:println(logLines[12]);
     validateLog(logLines[12], " level=INFO module=\"\" message=\"info log\" error={\"causes\":[],\"message\":{\"code\":403,\"details\":\"Authentication failed\"},\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"info.bal\",\"lineNumber\":35}]}");
 }
 
@@ -156,13 +146,10 @@ public function testPrintWarnLogfmt() returns error? {
     validateLog(logLines[5], " level=WARN module=\"\" message=\"warn log\"");
     validateLog(logLines[6], " level=WARN module=\"\" message=\"warn log\" username=\"Alex92\" id=845315 foo=true");
     validateLog(logLines[7], " level=WARN module=\"\" message=\"warn log\" username=\"Alex92\" id=845315");
-    //io:println(logLines[8]);
     validateLog(logLines[8], " level=WARN module=\"\" message=\"warn log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"warn.bal\",\"lineNumber\":22}]}");
-    //io:println(logLines[9]);
     validateLog(logLines[9], " level=WARN module=\"\" message=\"warn log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"warn.bal\",\"lineNumber\":22}]} username=\"Alex92\" id=845315 foo=true");
     validateLog(logLines[10], " level=WARN module=\"\" message=\"warn log\\t\\n\\r\\\\\\\"\" username=\"Alex92\\t\\n\\r\\\\\\\"\"");
     validateLog(logLines[11], " level=WARN module=\"\" message=\"warn log\" stackTrace=[\"callableName: f3  fileName: warn.bal lineNumber: 48\",\"callableName: f2  fileName: warn.bal lineNumber: 44\",\"callableName: f1  fileName: warn.bal lineNumber: 40\",\"callableName: main  fileName: warn.bal lineNumber: 29\"] username=\"Alex92\" id=845315");
-    //io:println(logLines[12]);
     validateLog(logLines[12], " level=WARN module=\"\" message=\"warn log\" error={\"causes\":[],\"message\":{\"code\":403,\"details\":\"Authentication failed\"},\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"warn.bal\",\"lineNumber\":35}]}");
 }
 

--- a/integration-tests/tests/tests_logfmt.bal
+++ b/integration-tests/tests/tests_logfmt.bal
@@ -46,25 +46,25 @@ const string CONFIG_PROJECT_GLOBAL_AND_DEFAULT_PACKAGE_LEVEL_LOGFMT = "tests/res
 const string CONFIG_PROJECT_GLOBAL_AND_MODULE_LEVEL_LOGFMT = "tests/resources/config/logfmt/log-project/global-and-module/Config.toml";
 const string CONFIG_OBSERVABILITY_PROJECT_LOGFMT = "tests/resources/config/logfmt/observability-project/Config.toml";
 
-const string MESSAGE_ERROR_LOGFMT = " level = ERROR module = \"\" message = \"error log\"";
-const string MESSAGE_WARN_LOGFMT = " level = WARN module = \"\" message = \"warn log\"";
-const string MESSAGE_INFO_LOGFMT = " level = INFO module = \"\" message = \"info log\"";
-const string MESSAGE_DEBUG_LOGFMT = " level = DEBUG module = \"\" message = \"debug log\"";
+const string MESSAGE_ERROR_LOGFMT = " level=ERROR module=\"\" message=\"error log\"";
+const string MESSAGE_WARN_LOGFMT = " level=WARN module=\"\" message=\"warn log\"";
+const string MESSAGE_INFO_LOGFMT = " level=INFO module=\"\" message=\"info log\"";
+const string MESSAGE_DEBUG_LOGFMT = " level=DEBUG module=\"\" message=\"debug log\"";
 
-const string MESSAGE_ERROR_MAIN_LOGFMT = " level = ERROR module = myorg/myproject message = \"error log\\t\\n\\r\\\\\\\"\"";
-const string MESSAGE_WARN_MAIN_LOGFMT = " level = WARN module = myorg/myproject message = \"warn log\\t\\n\\r\\\\\\\"\"";
-const string MESSAGE_INFO_MAIN_LOGFMT = " level = INFO module = myorg/myproject message = \"info log\\t\\n\\r\\\\\\\"\"";
-const string MESSAGE_DEBUG_MAIN_LOGFMT = " level = DEBUG module = myorg/myproject message = \"debug log\\t\\n\\r\\\\\\\"\"";
+const string MESSAGE_ERROR_MAIN_LOGFMT = " level=ERROR module=myorg/myproject message=\"error log\\t\\n\\r\\\\\\\"\"";
+const string MESSAGE_WARN_MAIN_LOGFMT = " level=WARN module=myorg/myproject message=\"warn log\\t\\n\\r\\\\\\\"\"";
+const string MESSAGE_INFO_MAIN_LOGFMT = " level=INFO module=myorg/myproject message=\"info log\\t\\n\\r\\\\\\\"\"";
+const string MESSAGE_DEBUG_MAIN_LOGFMT = " level=DEBUG module=myorg/myproject message=\"debug log\\t\\n\\r\\\\\\\"\"";
 
-const string MESSAGE_ERROR_FOO_LOGFMT = " level = ERROR module = myorg/myproject.foo message = \"error log\\t\\n\\r\\\\\\\"\"";
-const string MESSAGE_WARN_FOO_LOGFMT = " level = WARN module = myorg/myproject.foo message = \"warn log\\t\\n\\r\\\\\\\"\"";
-const string MESSAGE_INFO_FOO_LOGFMT = " level = INFO module = myorg/myproject.foo message = \"info log\\t\\n\\r\\\\\\\"\"";
-const string MESSAGE_DEBUG_FOO_LOGFMT = " level = DEBUG module = myorg/myproject.foo message = \"debug log\\t\\n\\r\\\\\\\"\"";
+const string MESSAGE_ERROR_FOO_LOGFMT = " level=ERROR module=myorg/myproject.foo message=\"error log\\t\\n\\r\\\\\\\"\"";
+const string MESSAGE_WARN_FOO_LOGFMT = " level=WARN module=myorg/myproject.foo message=\"warn log\\t\\n\\r\\\\\\\"\"";
+const string MESSAGE_INFO_FOO_LOGFMT = " level=INFO module=myorg/myproject.foo message=\"info log\\t\\n\\r\\\\\\\"\"";
+const string MESSAGE_DEBUG_FOO_LOGFMT = " level=DEBUG module=myorg/myproject.foo message=\"debug log\\t\\n\\r\\\\\\\"\"";
 
-const string MESSAGE_ERROR_BAR_LOGFMT = " level = ERROR module = myorg/myproject.bar message = \"error log\\t\\n\\r\\\\\\\"\"";
-const string MESSAGE_WARN_BAR_LOGFMT = " level = WARN module = myorg/myproject.bar message = \"warn log\\t\\n\\r\\\\\\\"\"";
-const string MESSAGE_INFO_BAR_LOGFMT = " level = INFO module = myorg/myproject.bar message = \"info log\\t\\n\\r\\\\\\\"\"";
-const string MESSAGE_DEBUG_BAR_LOGFMT = " level = DEBUG module = myorg/myproject.bar message = \"debug log\\t\\n\\r\\\\\\\"\"";
+const string MESSAGE_ERROR_BAR_LOGFMT = " level=ERROR module=myorg/myproject.bar message=\"error log\\t\\n\\r\\\\\\\"\"";
+const string MESSAGE_WARN_BAR_LOGFMT = " level=WARN module=myorg/myproject.bar message=\"warn log\\t\\n\\r\\\\\\\"\"";
+const string MESSAGE_INFO_BAR_LOGFMT = " level=INFO module=myorg/myproject.bar message=\"info log\\t\\n\\r\\\\\\\"\"";
+const string MESSAGE_DEBUG_BAR_LOGFMT = " level=DEBUG module=myorg/myproject.bar message=\"debug log\\t\\n\\r\\\\\\\"\"";
 
 configurable string bal_exec_path = ?;
 configurable string temp_dir_path = ?;
@@ -80,14 +80,18 @@ public function testPrintDebugLogfmt() returns error? {
     string outText = check sc.read(100000);
     string[] logLines = re`\n`.split(outText.trim());
     test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
-    validateLog(logLines[5], " level = DEBUG module = \"\" message = \"debug log\"");
-    validateLog(logLines[6], " level = DEBUG module = \"\" message = \"debug log\" username = \"Alex92\" id = 845315 foo = true");
-    validateLog(logLines[7], " level = DEBUG module = \"\" message = \"debug log\" username = \"Alex92\" id = 845315");
-    validateLog(logLines[8], " level = DEBUG module = \"\" message = \"debug log\" error = \"bad sad\"");
-    validateLog(logLines[9], " level = DEBUG module = \"\" message = \"debug log\" error = \"bad sad\" username = \"Alex92\" id = 845315 foo = true");
-    validateLog(logLines[10], " level = DEBUG module = \"\" message = \"debug log\\t\\n\\r\\\\\\\"\" username = \"Alex92\\t\\n\\r\\\\\\\"\"");
-    validateLog(logLines[11], " level = DEBUG module = \"\" message = \"debug log\" stackTrace = [\"callableName: f3  fileName: debug.bal lineNumber: 48\",\"callableName: f2  fileName: debug.bal lineNumber: 44\",\"callableName: f1  fileName: debug.bal lineNumber: 40\",\"callableName: main  fileName: debug.bal lineNumber: 29\"] username = \"Alex92\" id = 845315");
-    validateLog(logLines[12], " level = DEBUG module = \"\" message = \"debug log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
+    validateLog(logLines[5], " level=DEBUG module=\"\" message=\"debug log\"");
+    validateLog(logLines[6], " level=DEBUG module=\"\" message=\"debug log\" username=\"Alex92\" id=845315 foo=true");
+    validateLog(logLines[7], " level=DEBUG module=\"\" message=\"debug log\" username=\"Alex92\" id=845315");
+    //io:println(logLines[8]);
+    validateLog(logLines[8], " level=DEBUG module=\"\" message=\"debug log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"debug.bal\",\"lineNumber\":22}]}");
+    //io:println(logLines[9]);
+    validateLog(logLines[9], " level=DEBUG module=\"\" message=\"debug log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"debug.bal\",\"lineNumber\":22}]} username=\"Alex92\" id=845315 foo=true");
+    //io:println(logLines[10]);
+    validateLog(logLines[10], " level=DEBUG module=\"\" message=\"debug log\\t\\n\\r\\\\\\\"\" username=\"Alex92\\t\\n\\r\\\\\\\"\"");
+    validateLog(logLines[11], " level=DEBUG module=\"\" message=\"debug log\" stackTrace=[\"callableName: f3  fileName: debug.bal lineNumber: 48\",\"callableName: f2  fileName: debug.bal lineNumber: 44\",\"callableName: f1  fileName: debug.bal lineNumber: 40\",\"callableName: main  fileName: debug.bal lineNumber: 29\"] username=\"Alex92\" id=845315");
+    //io:println(logLines[12]);
+    validateLog(logLines[12], " level=DEBUG module=\"\" message=\"debug log\" error={\"causes\":[],\"message\":{\"code\":403,\"details\":\"Authentication failed\"},\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"debug.bal\",\"lineNumber\":35}]}");
 }
 
 @test:Config {}
@@ -101,14 +105,17 @@ public function testPrintErrorLogfmt() returns error? {
     string outText = check sc.read(100000);
     string[] logLines = re`\n`.split(outText.trim());
     test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
-    validateLog(logLines[5], " level = ERROR module = \"\" message = \"error log\"");
-    validateLog(logLines[6], " level = ERROR module = \"\" message = \"error log\" username = \"Alex92\" id = 845315 foo = true");
-    validateLog(logLines[7], " level = ERROR module = \"\" message = \"error log\" username = \"Alex92\" id = 845315");
-    validateLog(logLines[8], " level = ERROR module = \"\" message = \"error log\" error = \"bad sad\"");
-    validateLog(logLines[9], " level = ERROR module = \"\" message = \"error log\" error = \"bad sad\" username = \"Alex92\" id = 845315 foo = true");
-    validateLog(logLines[10], " level = ERROR module = \"\" message = \"error log\\t\\n\\r\\\\\\\"\" username = \"Alex92\\t\\n\\r\\\\\\\"\"");
-    validateLog(logLines[11], " level = ERROR module = \"\" message = \"error log\" stackTrace = [\"callableName: f3  fileName: error.bal lineNumber: 48\",\"callableName: f2  fileName: error.bal lineNumber: 44\",\"callableName: f1  fileName: error.bal lineNumber: 40\",\"callableName: main  fileName: error.bal lineNumber: 29\"] username = \"Alex92\" id = 845315");
-    validateLog(logLines[12], " level = ERROR module = \"\" message = \"error log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
+    validateLog(logLines[5], " level=ERROR module=\"\" message=\"error log\"");
+    validateLog(logLines[6], " level=ERROR module=\"\" message=\"error log\" username=\"Alex92\" id=845315 foo=true");
+    validateLog(logLines[7], " level=ERROR module=\"\" message=\"error log\" username=\"Alex92\" id=845315");
+    //io:println(logLines[8]);
+    validateLog(logLines[8], " level=ERROR module=\"\" message=\"error log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"error.bal\",\"lineNumber\":22}]}");
+    //io:println(logLines[9]);
+    validateLog(logLines[9], " level=ERROR module=\"\" message=\"error log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"error.bal\",\"lineNumber\":22}]} username=\"Alex92\" id=845315 foo=true");
+    validateLog(logLines[10], " level=ERROR module=\"\" message=\"error log\\t\\n\\r\\\\\\\"\" username=\"Alex92\\t\\n\\r\\\\\\\"\"");
+    validateLog(logLines[11], " level=ERROR module=\"\" message=\"error log\" stackTrace=[\"callableName: f3  fileName: error.bal lineNumber: 48\",\"callableName: f2  fileName: error.bal lineNumber: 44\",\"callableName: f1  fileName: error.bal lineNumber: 40\",\"callableName: main  fileName: error.bal lineNumber: 29\"] username=\"Alex92\" id=845315");
+    //io:println(logLines[12]);
+    validateLog(logLines[12], " level=ERROR module=\"\" message=\"error log\" error={\"causes\":[],\"message\":{\"code\":403,\"details\":\"Authentication failed\"},\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"error.bal\",\"lineNumber\":35}]}");
 }
 
 @test:Config {}
@@ -122,14 +129,17 @@ public function testPrintInfoLogfmt() returns error? {
     string outText = check sc.read(100000);
     string[] logLines = re`\n`.split(outText.trim());
     test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
-    validateLog(logLines[5], " level = INFO module = \"\" message = \"info log\"");
-    validateLog(logLines[6], " level = INFO module = \"\" message = \"info log\" username = \"Alex92\" id = 845315 foo = true");
-    validateLog(logLines[7], " level = INFO module = \"\" message = \"info log\" username = \"Alex92\" id = 845315");
-    validateLog(logLines[8], " level = INFO module = \"\" message = \"info log\" error = \"bad sad\"");
-    validateLog(logLines[9], " level = INFO module = \"\" message = \"info log\" error = \"bad sad\" username = \"Alex92\" id = 845315 foo = true");
-    validateLog(logLines[10], " level = INFO module = \"\" message = \"info log\\t\\n\\r\\\\\\\"\" username = \"Alex92\\t\\n\\r\\\\\\\"\"");
-    validateLog(logLines[11], " level = INFO module = \"\" message = \"info log\" stackTrace = [\"callableName: f3  fileName: info.bal lineNumber: 48\",\"callableName: f2  fileName: info.bal lineNumber: 44\",\"callableName: f1  fileName: info.bal lineNumber: 40\",\"callableName: main  fileName: info.bal lineNumber: 29\"] username = \"Alex92\" id = 845315");
-    validateLog(logLines[12], " level = INFO module = \"\" message = \"info log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
+    validateLog(logLines[5], " level=INFO module=\"\" message=\"info log\"");
+    validateLog(logLines[6], " level=INFO module=\"\" message=\"info log\" username=\"Alex92\" id=845315 foo=true");
+    validateLog(logLines[7], " level=INFO module=\"\" message=\"info log\" username=\"Alex92\" id=845315");
+    //io:println(logLines[8]);
+    validateLog(logLines[8], " level=INFO module=\"\" message=\"info log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"info.bal\",\"lineNumber\":22}]}");
+    //io:println(logLines[9]);
+    validateLog(logLines[9], " level=INFO module=\"\" message=\"info log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"info.bal\",\"lineNumber\":22}]} username=\"Alex92\" id=845315 foo=true");
+    validateLog(logLines[10], " level=INFO module=\"\" message=\"info log\\t\\n\\r\\\\\\\"\" username=\"Alex92\\t\\n\\r\\\\\\\"\"");
+    validateLog(logLines[11], " level=INFO module=\"\" message=\"info log\" stackTrace=[\"callableName: f3  fileName: info.bal lineNumber: 48\",\"callableName: f2  fileName: info.bal lineNumber: 44\",\"callableName: f1  fileName: info.bal lineNumber: 40\",\"callableName: main  fileName: info.bal lineNumber: 29\"] username=\"Alex92\" id=845315");
+    //io:println(logLines[12]);
+    validateLog(logLines[12], " level=INFO module=\"\" message=\"info log\" error={\"causes\":[],\"message\":{\"code\":403,\"details\":\"Authentication failed\"},\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"info.bal\",\"lineNumber\":35}]}");
 }
 
 @test:Config {}
@@ -143,14 +153,17 @@ public function testPrintWarnLogfmt() returns error? {
     string outText = check sc.read(100000);
     string[] logLines = re`\n`.split(outText.trim());
     test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
-    validateLog(logLines[5], " level = WARN module = \"\" message = \"warn log\"");
-    validateLog(logLines[6], " level = WARN module = \"\" message = \"warn log\" username = \"Alex92\" id = 845315 foo = true");
-    validateLog(logLines[7], " level = WARN module = \"\" message = \"warn log\" username = \"Alex92\" id = 845315");
-    validateLog(logLines[8], " level = WARN module = \"\" message = \"warn log\" error = \"bad sad\"");
-    validateLog(logLines[9], " level = WARN module = \"\" message = \"warn log\" error = \"bad sad\" username = \"Alex92\" id = 845315 foo = true");
-    validateLog(logLines[10], " level = WARN module = \"\" message = \"warn log\\t\\n\\r\\\\\\\"\" username = \"Alex92\\t\\n\\r\\\\\\\"\"");
-    validateLog(logLines[11], " level = WARN module = \"\" message = \"warn log\" stackTrace = [\"callableName: f3  fileName: warn.bal lineNumber: 48\",\"callableName: f2  fileName: warn.bal lineNumber: 44\",\"callableName: f1  fileName: warn.bal lineNumber: 40\",\"callableName: main  fileName: warn.bal lineNumber: 29\"] username = \"Alex92\" id = 845315");
-    validateLog(logLines[12], " level = WARN module = \"\" message = \"warn log\" error = {\"code\":403,\"details\":\"Authentication failed\"}");
+    validateLog(logLines[5], " level=WARN module=\"\" message=\"warn log\"");
+    validateLog(logLines[6], " level=WARN module=\"\" message=\"warn log\" username=\"Alex92\" id=845315 foo=true");
+    validateLog(logLines[7], " level=WARN module=\"\" message=\"warn log\" username=\"Alex92\" id=845315");
+    //io:println(logLines[8]);
+    validateLog(logLines[8], " level=WARN module=\"\" message=\"warn log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"warn.bal\",\"lineNumber\":22}]}");
+    //io:println(logLines[9]);
+    validateLog(logLines[9], " level=WARN module=\"\" message=\"warn log\" error={\"causes\":[],\"message\":\"bad sad\",\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"warn.bal\",\"lineNumber\":22}]} username=\"Alex92\" id=845315 foo=true");
+    validateLog(logLines[10], " level=WARN module=\"\" message=\"warn log\\t\\n\\r\\\\\\\"\" username=\"Alex92\\t\\n\\r\\\\\\\"\"");
+    validateLog(logLines[11], " level=WARN module=\"\" message=\"warn log\" stackTrace=[\"callableName: f3  fileName: warn.bal lineNumber: 48\",\"callableName: f2  fileName: warn.bal lineNumber: 44\",\"callableName: f1  fileName: warn.bal lineNumber: 40\",\"callableName: main  fileName: warn.bal lineNumber: 29\"] username=\"Alex92\" id=845315");
+    //io:println(logLines[12]);
+    validateLog(logLines[12], " level=WARN module=\"\" message=\"warn log\" error={\"causes\":[],\"message\":{\"code\":403,\"details\":\"Authentication failed\"},\"detail\":{},\"stackTrace\":[{\"callableName\":\"main\",\"moduleName\":(),\"fileName\":\"warn.bal\",\"lineNumber\":35}]}");
 }
 
 @test:Config {}
@@ -318,10 +331,10 @@ public function testObservabilityLogfmt() returns error? {
     string outText2 = check sc2.read(100000);
     string[] ioLines = re`\n`.split(outText2.trim());
     string spanContext = ioLines[1];
-    validateLog(logLines[5], string ` level = ERROR module = myorg/myproject message = "error log" ${spanContext}`);
-    validateLog(logLines[6], string ` level = WARN module = myorg/myproject message = "warn log" ${spanContext}`);
-    validateLog(logLines[7], string ` level = INFO module = myorg/myproject message = "info log" ${spanContext}`);
-    validateLog(logLines[8], string ` level = DEBUG module = myorg/myproject message = "debug log" ${spanContext}`);
+    validateLog(logLines[5], string ` level=ERROR module=myorg/myproject message="error log" ${spanContext}`);
+    validateLog(logLines[6], string ` level=WARN module=myorg/myproject message="warn log" ${spanContext}`);
+    validateLog(logLines[7], string ` level=INFO module=myorg/myproject message="info log" ${spanContext}`);
+    validateLog(logLines[8], string ` level=DEBUG module=myorg/myproject message="debug log" ${spanContext}`);
 }
 
 @test:Config {}
@@ -355,7 +368,7 @@ public function testSetOutputFileSingleFileAppendLogfmt() returns error? {
     test:assertTrue(fileWriteOutputLines is string[]);
     if fileWriteOutputLines is string[] {
         test:assertEquals(fileWriteOutputLines.length(), 5, INCORRECT_NUMBER_OF_LINES);
-        validateLog(fileWriteOutputLines[0], " level = INFO module = \"\" message = \"info log 0\"");
+        validateLog(fileWriteOutputLines[0], " level=INFO module=\"\" message=\"info log 0\"");
         validateLog(fileWriteOutputLines[1], MESSAGE_ERROR_LOGFMT);
         validateLog(fileWriteOutputLines[2], MESSAGE_WARN_LOGFMT);
         validateLog(fileWriteOutputLines[3], MESSAGE_INFO_LOGFMT);
@@ -425,7 +438,7 @@ public function testSetOutputFileProjectAppendLogfmt() returns error? {
     test:assertTrue(fileWriteOutputLines is string[]);
     if fileWriteOutputLines is string[] {
         test:assertEquals(fileWriteOutputLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
-        validateLog(fileWriteOutputLines[0], " level = INFO module = \"\" message = \"info log 0\"");
+        validateLog(fileWriteOutputLines[0], " level=INFO module=\"\" message=\"info log 0\"");
         validateLog(fileWriteOutputLines[1], MESSAGE_ERROR_MAIN_LOGFMT);
         validateLog(fileWriteOutputLines[2], MESSAGE_WARN_MAIN_LOGFMT);
         validateLog(fileWriteOutputLines[3], MESSAGE_INFO_MAIN_LOGFMT);
@@ -453,7 +466,7 @@ public function testSetOutputFileProjectAppendLogfmt2() returns error? {
     test:assertTrue(fileWriteOutputLines is string[]);
     if fileWriteOutputLines is string[] {
         test:assertEquals(fileWriteOutputLines.length(), 9, INCORRECT_NUMBER_OF_LINES);
-        validateLog(fileWriteOutputLines[0], " level = INFO module = \"\" message = \"info log 0\"");
+        validateLog(fileWriteOutputLines[0], " level=INFO module=\"\" message=\"info log 0\"");
         validateLog(fileWriteOutputLines[1], MESSAGE_ERROR_FOO_LOGFMT);
         validateLog(fileWriteOutputLines[2], MESSAGE_WARN_FOO_LOGFMT);
         validateLog(fileWriteOutputLines[3], MESSAGE_INFO_FOO_LOGFMT);
@@ -466,8 +479,8 @@ public function testSetOutputFileProjectAppendLogfmt2() returns error? {
 }
 
 isolated function validateLog(string log, string output) {
-    test:assertTrue(log.includes("time ="), "log does not contain the time");
-    test:assertTrue(log.includes(output), "log does not contain the required output");
+    test:assertTrue(log.includes("time="), "log does not contain the time");
+    test:assertTrue(log.includes(output), string `log: ${log} does not contain the output: ${output}`);
 }
 
 function exec(@untainted string command, @untainted map<string> env = {},


### PR DESCRIPTION
## Purpose

This PR,
- Adds full error details to the log message
- Remove the additional space in between the key and value in logFMT format. 
   Current log output: `message = "hello" foo = "bar"`
   New log output: `message="hello" foo="bar"`

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/3265

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
