### PR TITLE
Add groupId, artifactId, scope to relevant platform dependencies

### DIFF
--- a/integration-tests/Ballerina.toml
+++ b/integration-tests/Ballerina.toml
@@ -4,10 +4,17 @@ name = "integration_tests"
 version = "@toml.version@"
 
 [[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "log-native"
 path = "../native/build/libs/log-native-@project.version@.jar"
 
 [[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "log-test-utils"
+scope = "testOnly"
 path = "../test-utils/build/libs/log-test-utils-@project.version@.jar"
 
 [[platform.java17.dependency]]
+groupId = "io.ballerina.stdlib"
+artifactId = "io-native"
 path = "./lib/io-native-@io.native.version@.jar"


### PR DESCRIPTION
## Purpose
Ballerina tests use a custom URL Classloader to load the relevant classes for the test execution. Platform dependencies specified in `Ballerina.toml` are currently loaded into the System Classloader by adding them to the `-cp` argument of the `java` command.

To introduce an API to read static resources of a project in ballerina tests, the jar containing that API should be loaded to the URLClassloader. To do so, the platform dependencies that are native jars have to be added to this custom classloader. These native jars are identified by the groupId. 

Currently, intergration-tests are failing because `Ballerina.toml` does not have these fields specified.  This was noticed by triggering a FBP with the lang's new changes for the above mentioned change.
## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
