### PR TITLE
Fix integration tests failure when environment variable "CENTRAL_VERBOSE_ENABLED" value is set to true

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.8.0"
+distribution-version = "2201.9.0-20240418-091200-01b8493b"
 
 [[package]]
 org = "ballerina"
@@ -29,12 +29,38 @@ modules = [
 
 [[package]]
 org = "ballerina"
+name = "lang.__internal"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.object"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.array"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.__internal"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.error"
 version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
+
+[[package]]
+org = "ballerina"
+name = "lang.object"
+version = "0.0.0"
+scope = "testOnly"
 
 [[package]]
 org = "ballerina"
@@ -81,6 +107,7 @@ version = "0.0.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.array"},
 	{org = "ballerina", name = "lang.error"}
 ]
 modules = [

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -91,7 +91,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.2.0"
+version = "1.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/integration-tests/tests/tests_json.bal
+++ b/integration-tests/tests/tests_json.bal
@@ -306,7 +306,12 @@ public function testObservabilityJson() returns error? {
     io:ReadableCharacterChannel sc2 = new (readableOutResult, UTF_8);
     string outText2 = check sc2.read(100000);
     string[] ioLines = re`\n`.split(outText2);
-    string spanContext = ioLines[1];
+    string spanContext;
+    if (boolean:fromString(getEnvVal("CENTRAL_VERBOSE_ENABLED")) == true) {
+        spanContext = ioLines[ioLines.length() - 1];
+    } else {
+        spanContext = ioLines[1];
+    }
     validateLogJson(logLines[5], string `", "level":"ERROR", "module":"myorg/myproject", "message":"error log", ${spanContext}}`);
     validateLogJson(logLines[6], string `", "level":"WARN", "module":"myorg/myproject", "message":"warn log", ${spanContext}}`);
     validateLogJson(logLines[7], string `", "level":"INFO", "module":"myorg/myproject", "message":"info log", ${spanContext}}`);

--- a/integration-tests/tests/tests_logfmt.bal
+++ b/integration-tests/tests/tests_logfmt.bal
@@ -317,7 +317,12 @@ public function testObservabilityLogfmt() returns error? {
     io:ReadableCharacterChannel sc2 = new (readableOutResult, UTF_8);
     string outText2 = check sc2.read(100000);
     string[] ioLines = re`\n`.split(outText2.trim());
-    string spanContext = ioLines[1];
+    string spanContext;
+    if (boolean:fromString(getEnvVal("CENTRAL_VERBOSE_ENABLED")) == true) {
+        spanContext = ioLines[ioLines.length() - 1]; // last line  
+    } else {
+        spanContext = ioLines[1];
+    }
     validateLog(logLines[5], string ` level=ERROR module=myorg/myproject message="error log" ${spanContext}`);
     validateLog(logLines[6], string ` level=WARN module=myorg/myproject message="warn log" ${spanContext}`);
     validateLog(logLines[7], string ` level=INFO module=myorg/myproject message="info log" ${spanContext}`);
@@ -474,4 +479,9 @@ function exec(@untainted string command, @untainted map<string> env = {},
                      @untainted string? dir = (), @untainted string... args) returns Process|error = @java:Method {
     name: "exec",
     'class: "io.ballerina.stdlib.log.testutils.nativeimpl.Exec"
+} external;
+
+function getEnvVal(@untainted string key) returns string = @java:Method {
+    name: "getEnv",
+    'class: "io.ballerina.stdlib.log.testutils.utils.OSUtils"
 } external;

--- a/test-utils/src/main/java/io/ballerina/stdlib/log/testutils/utils/OSUtils.java
+++ b/test-utils/src/main/java/io/ballerina/stdlib/log/testutils/utils/OSUtils.java
@@ -25,6 +25,7 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import static io.ballerina.stdlib.log.testutils.nativeimpl.ModuleUtils.getModule;
 import static io.ballerina.stdlib.log.testutils.utils.OSConstants.PROCESS_FIELD;
@@ -77,5 +78,15 @@ public class OSUtils {
 
     public static boolean isValidDateTime(BString dateTime) {
         return dateTime.substring(0, 23).getValue().matches("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}");
+    }
+
+    /**
+     * Get the environment variable value.
+     * @param key Environment variable key
+     * @return  Environment variable value
+     */
+    public static BString getEnv(BString key) {
+        String envValue = System.getenv(key.getValue());
+        return StringUtils.fromString(Objects.requireNonNullElse(envValue, ""));
     }
 }


### PR DESCRIPTION
## Purpose
$Subject.

`testObservabilityJson`'s and `testObservabilityLogfmt`'s assertions depend on the log outputs. During the FBP, these two tests fail as FBP has set `CENTRAL_VERBOSE_ENABLED` to true. This verbose logs more information where these additional lines (wrong ones) are added to the assertion, ultimately causing the failure.

To reproduce this, export `CENTRAL_VERBOSE_ENABLED` with the value of `true` and build the module. The above tests will fail.

To mitigate this, a Java interops function is added to get the value of the environment variable and if verbose is enabled, the relevant string is found at the very bottom of the log.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
