### PR TITLE
Fix issue in asserting the standard output logs

### DIFF
--- a/integration-tests/tests/tests_logger.bal
+++ b/integration-tests/tests/tests_logger.bal
@@ -42,8 +42,11 @@ function testRootLoggerWithConfig() returns error? {
     io:ReadableCharacterChannel outCharStreamResult = new (outStreamResult, UTF_8);
     string outTextStdout = check outCharStreamResult.read(100000);
     string[] outLogLines = re `\n`.split(outTextStdout.trim());
-    test:assertEquals(outLogLines.length(), 1, INCORRECT_NUMBER_OF_LINES);
-    test:assertTrue(outLogLines[0].includes(string `"level":"ERROR", "module":"", "message":"error log", "env":"prod", "nodeId":"test-svc-001"`));
+    // Standard output has other logs which are related to Ballerina package resolution with central.
+    // Hence checking only the last line.
+    int outLogLinesCount = outLogLines.length();
+    test:assertTrue(outLogLinesCount >= 1, INCORRECT_NUMBER_OF_LINES);
+    test:assertTrue(outLogLines[outLogLinesCount - 1].includes(string `"level":"ERROR", "module":"", "message":"error log", "env":"prod", "nodeId":"test-svc-001"`));
     check outCharStreamResult.close();
 
     string[] fileLogs = check io:fileReadLines("build/tmp/output/root-logger.log");


### PR DESCRIPTION
## Purpose

The test is failing in publish workflow since standard out stream has other logs

This shows the entire logs added to the standard output: https://github.com/ballerina-platform/module-ballerina-log/actions/runs/17292310103/job/49082293344#step:10:190

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
