### PR TITLE
Change the parameter name msg to message in logging APIs

### DIFF
--- a/ballerina/logger.bal
+++ b/ballerina/logger.bal
@@ -18,35 +18,35 @@
 public type Logger isolated object {
    # Prints debug logs.
    #
-   # + msg - The message to be logged
+   # + message - The message to be logged
    # + 'error - The error struct to be logged
    # + stackTrace - The error stack trace to be logged
    # + keyValues - The key-value pairs to be logged
-   public isolated function printDebug(string|PrintableRawTemplate msg, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues);
+   public isolated function printDebug(string|PrintableRawTemplate message, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues);
 
    # Prints info logs.
-   # 
-   # + msg - The message to be logged
+   #
+   # + message - The message to be logged
    # + 'error - The error struct to be logged
    # + stackTrace - The error stack trace to be logged
    # + keyValues - The key-value pairs to be logged
-   public isolated function printInfo(string|PrintableRawTemplate msg, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues);
+   public isolated function printInfo(string|PrintableRawTemplate message, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues);
 
    # Prints warn logs.
-   # 
-   # + msg - The message to be logged
+   #
+   # + message - The message to be logged
    # + 'error - The error struct to be logged
    # + stackTrace - The error stack trace to be logged
    # + keyValues - The key-value pairs to be logged
-   public isolated function printWarn(string|PrintableRawTemplate msg, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues);
+   public isolated function printWarn(string|PrintableRawTemplate message, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues);
 
    # Prints error logs.
-   # 
-   # + msg - The message to be logged
+   #
+   # + message - The message to be logged
    # + 'error - The error struct to be logged
    # + stackTrace - The error stack trace to be logged
    # + keyValues - The key-value pairs to be logged
-   public isolated function printError(string|PrintableRawTemplate msg, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues);
+   public isolated function printError(string|PrintableRawTemplate message, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues);
 
    # Creates a new child/derived logger with the given key-values.
    #

--- a/ballerina/natives.bal
+++ b/ballerina/natives.bal
@@ -254,22 +254,22 @@ public isolated function evaluateTemplate(PrintableRawTemplate template, boolean
     return result;
 }
 
-isolated function processMessage(string|PrintableRawTemplate msg, boolean enableSensitiveDataMasking) returns string =>
-    msg !is string ? evaluateTemplate(msg, enableSensitiveDataMasking) : msg;
+isolated function processMessage(string|PrintableRawTemplate message, boolean enableSensitiveDataMasking) returns string =>
+    message !is string ? evaluateTemplate(message, enableSensitiveDataMasking) : message;
 
 # Prints debug logs.
 # ```ballerina
 # log:printDebug("debug message", id = 845315)
 # ```
 #
-# + msg - The message to be logged
+# + message - The message to be logged
 # + 'error - The error struct to be logged
 # + stackTrace - The error stack trace to be logged
 # + keyValues - The key-value pairs to be logged
-public isolated function printDebug(string|PrintableRawTemplate msg, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues) {
+public isolated function printDebug(string|PrintableRawTemplate message, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues) {
     // Added `stackTrace` as an optional param due to https://github.com/ballerina-platform/ballerina-lang/issues/34572
     string moduleName = getModuleName(keyValues);
-    rootLogger.print(DEBUG, moduleName, msg, 'error, stackTrace, keyValues);
+    rootLogger.print(DEBUG, moduleName, message, 'error, stackTrace, keyValues);
 }
 
 # Prints error logs.
@@ -278,13 +278,13 @@ public isolated function printDebug(string|PrintableRawTemplate msg, error? 'err
 # log:printError("error log with cause", 'error = e, id = 845315);
 # ```
 #
-# + msg - The message to be logged
+# + message - The message to be logged
 # + 'error - The error struct to be logged
 # + stackTrace - The error stack trace to be logged
 # + keyValues - The key-value pairs to be logged
-public isolated function printError(string|PrintableRawTemplate msg, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues) {
+public isolated function printError(string|PrintableRawTemplate message, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues) {
     string moduleName = getModuleName(keyValues);
-    rootLogger.print(ERROR, moduleName, msg, 'error, stackTrace, keyValues);
+    rootLogger.print(ERROR, moduleName, message, 'error, stackTrace, keyValues);
 }
 
 # Prints info logs.
@@ -292,13 +292,13 @@ public isolated function printError(string|PrintableRawTemplate msg, error? 'err
 # log:printInfo("info message", id = 845315)
 # ```
 #
-# + msg - The message to be logged
+# + message - The message to be logged
 # + 'error - The error struct to be logged
 # + stackTrace - The error stack trace to be logged
 # + keyValues - The key-value pairs to be logged
-public isolated function printInfo(string|PrintableRawTemplate msg, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues) {
+public isolated function printInfo(string|PrintableRawTemplate message, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues) {
     string moduleName = getModuleName(keyValues);
-    rootLogger.print(INFO, moduleName, msg, 'error, stackTrace, keyValues);
+    rootLogger.print(INFO, moduleName, message, 'error, stackTrace, keyValues);
 }
 
 # Prints warn logs.
@@ -306,13 +306,13 @@ public isolated function printInfo(string|PrintableRawTemplate msg, error? 'erro
 # log:printWarn("warn message", id = 845315)
 # ```
 #
-# + msg - The message to be logged
+# + message - The message to be logged
 # + 'error - The error struct to be logged
 # + stackTrace - The error stack trace to be logged
 # + keyValues - The key-value pairs to be logged
-public isolated function printWarn(string|PrintableRawTemplate msg, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues) {
+public isolated function printWarn(string|PrintableRawTemplate message, error? 'error = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues) {
     string moduleName = getModuleName(keyValues);
-    rootLogger.print(WARN, moduleName, msg, 'error, stackTrace, keyValues);
+    rootLogger.print(WARN, moduleName, message, 'error, stackTrace, keyValues);
 }
 
 # Sets the log output to a file. All subsequent logs of the entire application will be written to this file.

--- a/ballerina/root_logger.bal
+++ b/ballerina/root_logger.bal
@@ -166,24 +166,24 @@ isolated class RootLogger {
         self.loggerId = loggerId;
     }
 
-    public isolated function printDebug(string|PrintableRawTemplate msg, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
+    public isolated function printDebug(string|PrintableRawTemplate message, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
         string moduleName = getModuleName(keyValues, 3);
-        self.print(DEBUG, moduleName, msg, 'error, stackTrace, keyValues);
+        self.print(DEBUG, moduleName, message, 'error, stackTrace, keyValues);
     }
 
-    public isolated function printError(string|PrintableRawTemplate msg, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
+    public isolated function printError(string|PrintableRawTemplate message, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
         string moduleName = getModuleName(keyValues, 3);
-        self.print(ERROR, moduleName, msg, 'error, stackTrace, keyValues);
+        self.print(ERROR, moduleName, message, 'error, stackTrace, keyValues);
     }
 
-    public isolated function printInfo(string|PrintableRawTemplate msg, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
+    public isolated function printInfo(string|PrintableRawTemplate message, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
         string moduleName = getModuleName(keyValues, 3);
-        self.print(INFO, moduleName, msg, 'error, stackTrace, keyValues);
+        self.print(INFO, moduleName, message, 'error, stackTrace, keyValues);
     }
 
-    public isolated function printWarn(string|PrintableRawTemplate msg, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
+    public isolated function printWarn(string|PrintableRawTemplate message, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
         string moduleName = getModuleName(keyValues, 3);
-        self.print(WARN, moduleName, msg, 'error, stackTrace, keyValues);
+        self.print(WARN, moduleName, message, 'error, stackTrace, keyValues);
     }
 
     public isolated function withContext(*KeyValues keyValues) returns Logger {
@@ -206,7 +206,7 @@ isolated class RootLogger {
         }
     }
 
-    isolated function print(string logLevel, string moduleName, string|PrintableRawTemplate msg, error? err = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues) {
+    isolated function print(string logLevel, string moduleName, string|PrintableRawTemplate message, error? err = (), error:StackFrame[]? stackTrace = (), *KeyValues keyValues) {
         Level effectiveLevel = self.getLevel();
         if moduleName.length() > 0 {
             Level? moduleLevel = getModuleLevelNative(moduleName);
@@ -217,7 +217,7 @@ isolated class RootLogger {
         if !isLevelEnabled(effectiveLevel, logLevel) {
             return;
         }
-        printLog(logLevel, moduleName, msg, self.format, self.destinations, self.keyValues,
+        printLog(logLevel, moduleName, message, self.format, self.destinations, self.keyValues,
                 self.enableSensitiveDataMasking, err, stackTrace, keyValues);
     }
 }
@@ -233,36 +233,36 @@ isolated class ChildLogger {
         self.keyValues = keyValues;
     }
 
-    public isolated function printDebug(string|PrintableRawTemplate msg, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
+    public isolated function printDebug(string|PrintableRawTemplate message, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
         KeyValues merged = self.mergeKeyValues(keyValues);
         if !merged.hasKey("module") {
              merged["module"] = getInvokedModuleName(2);
         }
-        self.parent.printDebug(msg, 'error, stackTrace, merged);
+        self.parent.printDebug(message, 'error, stackTrace, merged);
     }
 
-    public isolated function printError(string|PrintableRawTemplate msg, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
+    public isolated function printError(string|PrintableRawTemplate message, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
         KeyValues merged = self.mergeKeyValues(keyValues);
         if !merged.hasKey("module") {
              merged["module"] = getInvokedModuleName(2);
         }
-        self.parent.printError(msg, 'error, stackTrace, merged);
+        self.parent.printError(message, 'error, stackTrace, merged);
     }
 
-    public isolated function printInfo(string|PrintableRawTemplate msg, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
+    public isolated function printInfo(string|PrintableRawTemplate message, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
         KeyValues merged = self.mergeKeyValues(keyValues);
         if !merged.hasKey("module") {
              merged["module"] = getInvokedModuleName(2);
         }
-        self.parent.printInfo(msg, 'error, stackTrace, merged);
+        self.parent.printInfo(message, 'error, stackTrace, merged);
     }
 
-    public isolated function printWarn(string|PrintableRawTemplate msg, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
+    public isolated function printWarn(string|PrintableRawTemplate message, error? 'error, error:StackFrame[]? stackTrace, *KeyValues keyValues) {
         KeyValues merged = self.mergeKeyValues(keyValues);
         if !merged.hasKey("module") {
              merged["module"] = getInvokedModuleName(2);
         }
-        self.parent.printWarn(msg, 'error, stackTrace, merged);
+        self.parent.printWarn(message, 'error, stackTrace, merged);
     }
 
     public isolated function withContext(*KeyValues keyValues) returns Logger {
@@ -300,7 +300,7 @@ isolated class ChildLogger {
     }
 }
 
-isolated function printLog(string logLevel, string moduleName, string|PrintableRawTemplate msg,
+isolated function printLog(string logLevel, string moduleName, string|PrintableRawTemplate message,
         LogFormat format, readonly & OutputDestination[] destinations, readonly & KeyValues contextKeyValues,
         boolean enableSensitiveDataMasking, error? err = (), error:StackFrame[]? stackTrace = (),
         KeyValues callSiteKeyValues = {}) {
@@ -308,7 +308,7 @@ isolated function printLog(string logLevel, string moduleName, string|PrintableR
         time: getCurrentTime(),
         level: logLevel,
         module: moduleName,
-        message: processMessage(msg, enableSensitiveDataMasking)
+        message: processMessage(message, enableSensitiveDataMasking)
     };
     if err is error {
         logRecord.'error = getFullErrorDetails(err);


### PR DESCRIPTION
## Purpose
$title

## Fixes https://github.com/ballerina-platform/ballerina-library/issues/8740


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Parameter Naming Consistency Update for Logging APIs

This pull request renames the first parameter in all logging API methods from `msg` to `message` across the Ballerina logging module, improving consistency with industry standards and alignment with logging systems like WSO2 Integrator.

### Changes Made

**Core Logging Methods** (`Logger`, `RootLogger`, and `ChildLogger`):
- Renamed parameter `msg` → `message` in `printDebug()`, `printInfo()`, `printWarn()`, and `printError()` methods across:
  - `ballerina/logger.bal`
  - `ballerina/root_logger.bal`
  - Related child logger implementations

**Support Functions**:
- Updated `processMessage()` function in `ballerina/natives.bal` to use `message` parameter
- Updated `printLog()` helper function to use the renamed parameter
- Updated all internal method calls and documentation comments to reference `message` instead of `msg`

**Impact**: Total of 45 lines modified (+45/-45 across three files) with no changes to method logic, return types, or functional behavior—this is purely a parameter naming refactor for improved API consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->