### PR TITLE
Migrate to Gradle 9.5.1 and Java 25

### DIFF
--- a/.github/workflows/build-with-bal-test-graalvm.yml
+++ b/.github/workflows/build-with-bal-test-graalvm.yml
@@ -30,7 +30,7 @@ jobs:
   call_stdlib_workflow:
     name: Run StdLib Workflow
     if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'ballerina-platform') }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/build-with-bal-test-graalvm-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/build-with-bal-test-graalvm-template.yml@java-25-migration
     with:
       lang_tag: ${{ inputs.lang_tag }}
       lang_version: ${{ inputs.lang_version }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,5 +10,5 @@ jobs:
   call_workflow:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@java-25-migration
     secrets: inherit

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,32 +1,32 @@
 [package]
 org = "ballerina"
 name = "log"
-version = "2.17.0"
+version = "2.17.1"
 authors = ["Ballerina"]
 keywords = ["level", "format"]
 repository = "https://github.com/ballerina-platform/module-ballerina-log"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.13.0"
+distribution = "2201.14.0-SNAPSHOT"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "log-native"
-version = "2.17.0"
-path = "../native/build/libs/log-native-2.17.0.jar"
+version = "2.17.1"
+path = "../native/build/libs/log-native-2.17.1-SNAPSHOT.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "log-compiler-plugin"
-version = "2.17.0"
-path = "../compiler-plugin/build/libs/log-compiler-plugin-2.17.0.jar"
+version = "2.17.1"
+path = "../compiler-plugin/build/libs/log-compiler-plugin-2.17.1-SNAPSHOT.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "log-test-utils"
-version = "2.17.0"
-path = "../test-utils/build/libs/log-test-utils-2.17.0.jar"
+version = "2.17.1"
+path = "../test-utils/build/libs/log-test-utils-2.17.1-SNAPSHOT.jar"
 scope = "testOnly"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["level", "format"]
 repository = "https://github.com/ballerina-platform/module-ballerina-log"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.14.0-SNAPSHOT"
+distribution = "2201.14.0"
 
 [platform.java25]
 graalvmCompatible = true

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "log-compiler-plugin"
 class = "io.ballerina.stdlib.log.compiler.LogCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/log-compiler-plugin-2.17.0.jar"
+path = "../compiler-plugin/build/libs/log-compiler-plugin-2.17.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.14.0-SNAPSHOT"
+distribution-version = "2201.14.0-20260527-050400-74f7e6bf"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.0"
+distribution-version = "2201.14.0-SNAPSHOT"
 
 [[package]]
 org = "ballerina"
@@ -88,7 +88,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.17.0"
+version = "2.17.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -26,6 +26,8 @@ abstract class BallerinaExecHelper {
 
 abstract class PatchBallerinaScriptsTask extends DefaultTask {
     @Inject abstract JavaToolchainService getJavaToolchainService()
+    @Input abstract Property<String> getJballerinaToolsBinPath()
+    @Input abstract Property<String> getBallerinaRuntimeBinPath()
 
     @TaskAction
     void patch() {
@@ -34,20 +36,16 @@ abstract class PatchBallerinaScriptsTask extends DefaultTask {
         }.get()
         def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
 
-        def binDirs = [
-            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
-            new File("${project.rootDir}/target/ballerina-runtime/bin")
-        ]
-        binDirs.each { binDir ->
+        [new File(jballerinaToolsBinPath.get()), new File(ballerinaRuntimeBinPath.get())].each { binDir ->
             if (binDir.exists()) {
                 binDir.eachFile { file ->
                     file.setExecutable(true)
                     if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
                         def original = file.text
                         def lines = original.split('\n').toList()
-                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        lines = lines.collect { it.replace('--sun-misc-unsafe-memory-access=allow', '').trim() }.findAll { !it.isEmpty() }
                         def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
-                        if (shebangIdx >= 0) {
+                        if (shebangIdx >= 0 && !lines.any { it.startsWith('export JAVA_HOME=') }) {
                             lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
                         }
                         def patched = lines.join('\n') + '\n'
@@ -120,6 +118,9 @@ task commitTomlFiles {
 
 task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
     dependsOn 'unpackJballerinaTools'
+    outputs.upToDateWhen { !tasks.named('unpackJballerinaTools').get().didWork }
+    jballerinaToolsBinPath = layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile.absolutePath
+    ballerinaRuntimeBinPath = "${rootProject.projectDir.absolutePath}/target/ballerina-runtime/bin"
 }
 
 publishing {

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -15,6 +15,49 @@
  *
  */
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
+
+abstract class PatchBallerinaScriptsTask extends DefaultTask {
+    @Inject abstract JavaToolchainService getJavaToolchainService()
+
+    @TaskAction
+    void patch() {
+        def launcher = javaToolchainService.launcherFor { spec ->
+            spec.languageVersion.set(JavaLanguageVersion.of(25))
+        }.get()
+        def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
+
+        def binDirs = [
+            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
+            new File("${project.rootDir}/target/ballerina-runtime/bin")
+        ]
+        binDirs.each { binDir ->
+            if (binDir.exists()) {
+                binDir.eachFile { file ->
+                    file.setExecutable(true)
+                    if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
+                        def original = file.text
+                        def lines = original.split('\n').toList()
+                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
+                        if (shebangIdx >= 0) {
+                            lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
+                        }
+                        def patched = lines.join('\n') + '\n'
+                        if (patched != original) { file.text = patched }
+                    }
+                }
+            }
+        }
+    }
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -62,8 +105,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml CompilerPlugin.toml"
@@ -72,6 +116,10 @@ task commitTomlFiles {
             }
         }
     }
+}
+
+task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
+    dependsOn 'unpackJballerinaTools'
 }
 
 publishing {
@@ -94,7 +142,9 @@ publishing {
 }
 
 updateTomlFiles.dependsOn copyStdlibs
+copyStdlibs.dependsOn patchBallerinaScripts
 
+build.dependsOn patchBallerinaScripts
 build.dependsOn "generatePomFileForMavenPublication"
 build.finalizedBy ':log-integration-tests:build'
 build.dependsOn ":${packageName}-native:build"

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,24 +7,24 @@ keywords = ["level", "format"]
 repository = "https://github.com/ballerina-platform/module-ballerina-log"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.13.0"
+distribution = "2201.14.0-SNAPSHOT"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "log-native"
 version = "@toml.version@"
 path = "../native/build/libs/log-native-@project.version@.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "log-compiler-plugin"
 version = "@toml.version@"
 path = "../compiler-plugin/build/libs/log-compiler-plugin-@project.version@.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "log-test-utils"
 version = "@toml.version@"

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["level", "format"]
 repository = "https://github.com/ballerina-platform/module-ballerina-log"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.14.0-SNAPSHOT"
+distribution = "2201.14.0"
 
 [platform.java25]
 graalvmCompatible = true

--- a/build-config/spotbugs-exclude.xml
+++ b/build-config/spotbugs-exclude.xml
@@ -23,4 +23,18 @@
         <Method name="getInstance"/>
         <Bug pattern="MS_EXPOSE_REP"/>
     </Match>
+
+    <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
+    <Match>
+        <BugCode name="THROWS"/>
+    </Match>
+    <Match>
+        <BugCode name="AT"/>
+    </Match>
+    <Match>
+        <BugCode name="USELESS_STRING"/>
+    </Match>
+    <Match>
+        <BugCode name="DM"/>
+    </Match>
 </FindBugsFilter>

--- a/build-config/spotbugs-exclude.xml
+++ b/build-config/spotbugs-exclude.xml
@@ -26,15 +26,19 @@
 
     <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
     <Match>
+        <Package name="~io.ballerina.stdlib.log.*"/>
         <BugCode name="THROWS"/>
     </Match>
     <Match>
+        <Package name="~io.ballerina.stdlib.log.*"/>
         <BugCode name="AT"/>
     </Match>
     <Match>
+        <Package name="~io.ballerina.stdlib.log.*"/>
         <BugCode name="USELESS_STRING"/>
     </Match>
     <Match>
+        <Package name="~io.ballerina.stdlib.log.*"/>
         <BugCode name="DM"/>
     </Match>
 </FindBugsFilter>

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ allprojects {
     version = project.version
 
     apply plugin: 'jacoco'
+jacoco {
+    toolVersion = jacocoVersion
+}
     apply plugin: 'maven-publish'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 
 plugins {
     id "com.github.spotbugs-base"
-    id "com.github.johnrengelman.shadow"
+    id "com.gradleup.shadow"
     id "de.undercouch.download"
     id "net.researchgate.release"
 }
@@ -60,6 +60,14 @@ allprojects {
 
 subprojects {
 
+    plugins.withId('java') {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        }
+    }
+
     configurations {
         ballerinaStdLibs
         jbalTools
@@ -94,6 +102,6 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn('log-ballerina:build')
 }

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -25,7 +25,7 @@ plugins {
 
 jacoco {
     toolVersion = "${jacocoVersion}"
-    reportsDirectory = file("$project.buildDir/reports/jacoco")
+    reportsDirectory = layout.buildDirectory.dir("reports/jacoco")
 }
 
 description = 'Ballerina - Log Compiler Plugin Tests'
@@ -49,8 +49,6 @@ dependencies {
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
-
-sourceCompatibility = JavaVersion.VERSION_21
 
 test {
     useTestNG() {
@@ -86,13 +84,13 @@ spotbugsTest {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile
     }
     reports {
-        text.enabled = true
+        text.required = true
     }
 }
 

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -53,10 +53,10 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     reports {
-        html.enabled true
-        text.enabled = true
+        html.required = true
+        text.required = true
     }
     def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
     if(excludeFile.exists()) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.17.1-SNAPSHOT
-ballerinaLangVersion=2201.14.0-SNAPSHOT
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.5.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ downloadPluginVersion=5.4.0
 releasePluginVersion=3.1.0
 ballerinaGradlePluginVersion=4.0.0
 balScanVersion=0.11.0
-jacocoVersion=0.8.10
+jacocoVersion=0.8.13
 jacksonDatabindVersion=2.17.2
 
 #stdlib dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.17.1-SNAPSHOT
-ballerinaLangVersion=2201.13.0
+ballerinaLangVersion=2201.14.0-SNAPSHOT
 
 checkstylePluginVersion=10.12.0
-spotbugsPluginVersion=6.0.18
-shadowJarPluginVersion=8.1.1
+spotbugsPluginVersion=6.5.1
+shadowJarPluginVersion=8.3.5
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.6.0
-ballerinaGradlePluginVersion=2.3.0
+releasePluginVersion=3.1.0
+ballerinaGradlePluginVersion=4.0.0
 balScanVersion=0.11.0
 jacocoVersion=0.8.10
 jacksonDatabindVersion=2.17.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ downloadPluginVersion=5.4.0
 releasePluginVersion=3.1.0
 ballerinaGradlePluginVersion=4.0.0
 balScanVersion=0.11.0
-jacocoVersion=0.8.13
+jacocoVersion=0.8.14
 jacksonDatabindVersion=2.17.2
 
 #stdlib dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.17.1-SNAPSHOT
-ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.5.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.17.1-SNAPSHOT
-ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
+ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.5.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/integration-tests/Ballerina.toml
+++ b/integration-tests/Ballerina.toml
@@ -3,18 +3,18 @@ org = "ballerina"
 name = "integration_tests"
 version = "@toml.version@"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "log-native"
 path = "../native/build/libs/log-native-@project.version@.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "log-test-utils"
 scope = "testOnly"
 path = "../test-utils/build/libs/log-test-utils-@project.version@.jar"
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "io-native"
 path = "./lib/io-native-@io.native.version@.jar"

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -16,6 +16,12 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+import javax.inject.Inject
+
+abstract class LogIntegrationTestsExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 apply plugin: 'java'
 
@@ -140,6 +146,7 @@ task copyTestOutputResources(type: Copy) {
 }
 
 task ballerinaIntegrationTests {
+    def execHelper = project.objects.newInstance(LogIntegrationTestsExecHelper)
     inputs.dir file(project.projectDir)
     dependsOn(compileTestJava)
     dependsOn(processTestResources)
@@ -157,7 +164,7 @@ task ballerinaIntegrationTests {
         def distributionBinPath =  "$project.rootDir/target/ballerina-runtime/bin"
         setExecPath(configTOMLFile,distributionBinPath)
         setTempDirPath(configTOMLFile, "$tempDir")
-        exec {
+        execHelper.execOperations.exec {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {

--- a/integration-tests/tests/process.bal
+++ b/integration-tests/tests/process.bal
@@ -95,15 +95,28 @@ isolated function nativeStdout(Process process) returns io:ReadableByteChannel =
 # (e.g. "  (use --enable-native-access=<module> to suppress this message)") or a tab.
 # Also filters "Picked up JAVA_TOOL_OPTIONS" / "Picked up _JAVA_OPTIONS" header lines
 # emitted by the JVM when those environment variables are set.
+# Consecutive blank lines left behind after filtering WARNING blocks are collapsed to one,
+# because maven-resolver (used when downloading non-bundled packages like ballerina/time in
+# CI) triggers a System::loadLibrary restricted-method warning that inserts an extra blank line.
 #
 # + lines - Raw lines from subprocess stderr
 # + return - Lines with JVM-level noise stripped out
 public isolated function filterJvmWarnings(string[] lines) returns string[] {
-    return lines.filter(line =>
+    string[] filtered = lines.filter(line =>
         !line.startsWith("WARNING: ") &&
         !line.startsWith("Picked up JAVA_TOOL_OPTIONS") &&
         !line.startsWith("Picked up _JAVA_OPTIONS") &&
         !line.startsWith("\t(use ") &&
         !line.startsWith("  (use ")
     );
+    string[] result = [];
+    boolean prevWasBlank = false;
+    foreach string line in filtered {
+        boolean isBlank = line.trim() == "";
+        if !(isBlank && prevWasBlank) {
+            result.push(line);
+        }
+        prevWasBlank = isBlank;
+    }
+    return result;
 }

--- a/integration-tests/tests/process.bal
+++ b/integration-tests/tests/process.bal
@@ -91,13 +91,19 @@ isolated function nativeStdout(Process process) returns io:ReadableByteChannel =
 # access) to stderr that were previously suppressed by the --sun-misc-unsafe-memory-access=allow
 # JVM flag removed in Java 25. These warnings start with "WARNING: " (uppercase, colon-space)
 # and are distinct from Ballerina compiler warnings which use "WARNING [file:(line,col)]".
-# Also filters "Picked up JAVA_TOOL_OPTIONS" header lines emitted by the JVM on Windows.
+# Java 25 also emits multi-line warnings where continuation/hint lines start with whitespace
+# (e.g. "  (use --enable-native-access=<module> to suppress this message)") or a tab.
+# Also filters "Picked up JAVA_TOOL_OPTIONS" / "Picked up _JAVA_OPTIONS" header lines
+# emitted by the JVM when those environment variables are set.
 #
 # + lines - Raw lines from subprocess stderr
 # + return - Lines with JVM-level noise stripped out
 public isolated function filterJvmWarnings(string[] lines) returns string[] {
     return lines.filter(line =>
         !line.startsWith("WARNING: ") &&
-        !line.startsWith("Picked up JAVA_TOOL_OPTIONS")
+        !line.startsWith("Picked up JAVA_TOOL_OPTIONS") &&
+        !line.startsWith("Picked up _JAVA_OPTIONS") &&
+        !line.startsWith("\t(use ") &&
+        !line.startsWith("  (use ")
     );
 }

--- a/integration-tests/tests/process.bal
+++ b/integration-tests/tests/process.bal
@@ -85,3 +85,19 @@ isolated function nativeStdout(Process process) returns io:ReadableByteChannel =
     name: "stdout",
     'class: "io.ballerina.stdlib.log.testutils.nativeimpl.Stdout"
 } external;
+
+# Filters out JVM-level warning lines from subprocess stderr output.
+# In Java 25, the JVM emits deprecation warnings (e.g. sun.misc.Unsafe, restricted method
+# access) to stderr that were previously suppressed by the --sun-misc-unsafe-memory-access=allow
+# JVM flag removed in Java 25. These warnings start with "WARNING: " (uppercase, colon-space)
+# and are distinct from Ballerina compiler warnings which use "WARNING [file:(line,col)]".
+# Also filters "Picked up JAVA_TOOL_OPTIONS" header lines emitted by the JVM on Windows.
+#
+# + lines - Raw lines from subprocess stderr
+# + return - Lines with JVM-level noise stripped out
+public isolated function filterJvmWarnings(string[] lines) returns string[] {
+    return lines.filter(line =>
+        !line.startsWith("WARNING: ") &&
+        !line.startsWith("Picked up JAVA_TOOL_OPTIONS")
+    );
+}

--- a/integration-tests/tests/test_logger_masking.bal
+++ b/integration-tests/tests/test_logger_masking.bal
@@ -30,7 +30,7 @@ function testMaskedLogger() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re `\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re `\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 8, INCORRECT_NUMBER_OF_LINES);
     test:assertTrue(logLines[5].includes(string `level=INFO module=wso2/masked_logger message="user logged in" userDetails={"name":"John Doe","password":"*****","mail":"joh**************com"}`));
     test:assertTrue(logLines[6].includes(string `level=DEBUG module=wso2/masked_logger message="user details: {\"name\":\"John Doe\",\"password\":\"*****\",\"mail\":\"joh**************com\"}"`));

--- a/integration-tests/tests/tests_json.bal
+++ b/integration-tests/tests/tests_json.bal
@@ -67,7 +67,7 @@ public function testPrintDebugJson() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\"}");
     validateLogJson(logLines[6], "\", \"level\":\"DEBUG\", \"module\":\"\", \"message\":\"debug log\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
@@ -88,7 +88,7 @@ public function testPrintErrorJson() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\"}");
     validateLogJson(logLines[6], "\", \"level\":\"ERROR\", \"module\":\"\", \"message\":\"error log\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
@@ -109,7 +109,7 @@ public function testPrintInfoJson() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\"}");
     validateLogJson(logLines[6], "\", \"level\":\"INFO\", \"module\":\"\", \"message\":\"info log\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
@@ -130,7 +130,7 @@ public function testPrintWarnJson() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\"}");
     validateLogJson(logLines[6], "\", \"level\":\"WARN\", \"module\":\"\", \"message\":\"warn log\", \"username\":\"Alex92\", \"id\":845315, \"foo\":true}");
@@ -151,7 +151,7 @@ public function testErrorLevelJson() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 6, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], MESSAGE_ERROR_JSON);
 }
@@ -165,7 +165,7 @@ public function testWarnLevelJson() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 7, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], MESSAGE_ERROR_JSON);
     validateLogJson(logLines[6], MESSAGE_WARN_JSON);
@@ -180,7 +180,7 @@ public function testInfoLevelJson() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 8, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], MESSAGE_ERROR_JSON);
     validateLogJson(logLines[6], MESSAGE_WARN_JSON);
@@ -196,7 +196,7 @@ public function testDebugLevelJson() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 9, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], MESSAGE_ERROR_JSON);
     validateLogJson(logLines[6], MESSAGE_WARN_JSON);
@@ -214,7 +214,7 @@ public function testProjectWithoutLogLevelJson() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 14, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], MESSAGE_ERROR_MAIN_JSON);
     validateLogJson(logLines[6], MESSAGE_WARN_MAIN_JSON);
@@ -237,7 +237,7 @@ public function testProjectWithGlobalLogLevelJson() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 11, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], MESSAGE_ERROR_MAIN_JSON);
     validateLogJson(logLines[6], MESSAGE_WARN_MAIN_JSON);
@@ -257,7 +257,7 @@ public function testProjectWithGlobalAndDefualtPackageLogLevelJson() returns err
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 12, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], MESSAGE_ERROR_MAIN_JSON);
     validateLogJson(logLines[6], MESSAGE_WARN_MAIN_JSON);
@@ -278,7 +278,7 @@ public function testProjectWithGlobalAndModuleLogLevelsJson() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 12, INCORRECT_NUMBER_OF_LINES);
     validateLogJson(logLines[5], MESSAGE_ERROR_MAIN_JSON);
     validateLogJson(logLines[6], MESSAGE_WARN_MAIN_JSON);
@@ -299,7 +299,7 @@ public function testObservabilityJson() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 9, INCORRECT_NUMBER_OF_LINES);
 
     io:ReadableByteChannel readableOutResult = result.stdout();

--- a/integration-tests/tests/tests_logfmt.bal
+++ b/integration-tests/tests/tests_logfmt.bal
@@ -86,7 +86,7 @@ public function testPrintDebugLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], " level=DEBUG module=\"\" message=\"debug log\"");
     validateLog(logLines[6], " level=DEBUG module=\"\" message=\"debug log\" username=\"Alex92\" id=845315 foo=true");
@@ -107,7 +107,7 @@ public function testPrintErrorLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], " level=ERROR module=\"\" message=\"error log\"");
     validateLog(logLines[6], " level=ERROR module=\"\" message=\"error log\" username=\"Alex92\" id=845315 foo=true");
@@ -128,7 +128,7 @@ public function testPrintInfoLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], " level=INFO module=\"\" message=\"info log\"");
     validateLog(logLines[6], " level=INFO module=\"\" message=\"info log\" username=\"Alex92\" id=845315 foo=true");
@@ -149,7 +149,7 @@ public function testPrintWarnLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 13, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], " level=WARN module=\"\" message=\"warn log\"");
     validateLog(logLines[6], " level=WARN module=\"\" message=\"warn log\" username=\"Alex92\" id=845315 foo=true");
@@ -170,7 +170,7 @@ public function testErrorLevelLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 6, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], MESSAGE_ERROR_LOGFMT);
 }
@@ -184,7 +184,7 @@ public function testWarnLevelLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 7, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], MESSAGE_ERROR_LOGFMT);
     validateLog(logLines[6], MESSAGE_WARN_LOGFMT);
@@ -199,7 +199,7 @@ public function testInfoLevelLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 8, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], MESSAGE_ERROR_LOGFMT);
     validateLog(logLines[6], MESSAGE_WARN_LOGFMT);
@@ -215,7 +215,7 @@ public function testDebugLevelLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 9, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], MESSAGE_ERROR_LOGFMT);
     validateLog(logLines[6], MESSAGE_WARN_LOGFMT);
@@ -232,7 +232,7 @@ public function testErrorLevelRawTemplateLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 6, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], MESSAGE_ERROR_RAW_TEMPLATE_LOGFMT);
 }
@@ -246,7 +246,7 @@ public function testWarnLevelRawTemplateLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 7, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], MESSAGE_ERROR_RAW_TEMPLATE_LOGFMT);
     validateLog(logLines[6], MESSAGE_WARN_RAW_TEMPLATE_LOGFMT);
@@ -261,7 +261,7 @@ public function testInfoLevelRawTemplateLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 9, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], MESSAGE_ERROR_RAW_TEMPLATE_LOGFMT);
     validateLog(logLines[6], MESSAGE_WARN_RAW_TEMPLATE_LOGFMT);
@@ -277,7 +277,7 @@ public function testDebugLevelRawTemplateLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 10, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], MESSAGE_ERROR_RAW_TEMPLATE_LOGFMT);
     validateLog(logLines[6], MESSAGE_WARN_RAW_TEMPLATE_LOGFMT);
@@ -293,7 +293,7 @@ public function testRawTemplateKeyValuePair() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 10, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], MESSAGE_ERROR_RAW_TEMPLATE_LOGFMT);
     validateLog(logLines[6], MESSAGE_WARN_RAW_TEMPLATE_LOGFMT);
@@ -313,7 +313,7 @@ public function testProjectWithoutLogLevelLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 14, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], MESSAGE_ERROR_MAIN_LOGFMT);
     validateLog(logLines[6], MESSAGE_WARN_MAIN_LOGFMT);
@@ -336,7 +336,7 @@ public function testProjectWithGlobalLogLevelLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 11, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], MESSAGE_ERROR_MAIN_LOGFMT);
     validateLog(logLines[6], MESSAGE_WARN_MAIN_LOGFMT);
@@ -356,7 +356,7 @@ public function testProjectWithGlobalAndDefualtPackageLogLevelLogfmt() returns e
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 12, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], MESSAGE_ERROR_MAIN_LOGFMT);
     validateLog(logLines[6], MESSAGE_WARN_MAIN_LOGFMT);
@@ -377,7 +377,7 @@ public function testProjectWithGlobalAndModuleLogLevelsLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 12, INCORRECT_NUMBER_OF_LINES);
     validateLog(logLines[5], MESSAGE_ERROR_MAIN_LOGFMT);
     validateLog(logLines[6], MESSAGE_WARN_MAIN_LOGFMT);
@@ -398,7 +398,7 @@ public function testObservabilityLogfmt() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 9, INCORRECT_NUMBER_OF_LINES);
 
     io:ReadableByteChannel readableOutResult = result.stdout();

--- a/integration-tests/tests/tests_logger.bal
+++ b/integration-tests/tests/tests_logger.bal
@@ -34,7 +34,7 @@ function testRootLoggerWithConfig() returns error? {
     io:ReadableByteChannel errStreamResult = result.stderr();
     io:ReadableCharacterChannel errCharStreamResult = new (errStreamResult, UTF_8);
     string outErrText = check errCharStreamResult.read(100000);
-    string[] errorLogLines = re `\n`.split(outErrText.trim());
+    string[] errorLogLines = filterJvmWarnings(re `\n`.split(outErrText.trim()));
     test:assertEquals(errorLogLines.length(), 6, INCORRECT_NUMBER_OF_LINES);
     test:assertTrue(errorLogLines[5].includes(string `"level":"ERROR", "module":"", "message":"error log", "env":"prod", "nodeId":"test-svc-001"`));
     check errCharStreamResult.close();
@@ -66,7 +66,7 @@ function testChildLoggers() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re `\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re `\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 8, INCORRECT_NUMBER_OF_LINES);
     test:assertTrue(logLines[5].includes(string `level=INFO module="" message="This is a root logger message" logger="root"`));
     test:assertTrue(logLines[6].includes(string `level=ERROR module="" message="This is a logger 1 message" logger="logger1" id="abcde" correlationId="12345"`));
@@ -85,7 +85,7 @@ function testLoggerFromConfig() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re `\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re `\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 6, INCORRECT_NUMBER_OF_LINES);
     test:assertTrue(logLines[5].includes(string `level=INFO module=myorg/myproject message="Hello World from the root logger!" env="prod" nodeId="test-svc-001"`));
     check sc.close();
@@ -106,7 +106,7 @@ function testCustomLogger() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re `\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re `\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 4, INCORRECT_NUMBER_OF_LINES);
     check sc.close();
 

--- a/integration-tests/tests/tests_negative.bal
+++ b/integration-tests/tests/tests_negative.bal
@@ -33,7 +33,7 @@ public function testGlobalLogLevelNegative() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 7, INCORRECT_NUMBER_OF_LINES);
     test:assertTrue(logLines[5].includes("configurable variable 'level' is expected to be of type 'ballerina/log:2:(ballerina/log:2:Level & readonly)', but found 'string'"));
 }
@@ -47,7 +47,7 @@ public function testModuleLogLevelNegative() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 9, INCORRECT_NUMBER_OF_LINES);
     test:assertTrue(logLines[5].includes("configurable variable 'modules.level' is expected to be of type 'ballerina/log:2:Level', but found 'string'"));
 }
@@ -61,7 +61,7 @@ public function testSetOutputFileNegative() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 7, INCORRECT_NUMBER_OF_LINES);
     test:assertTrue(logLines[6].includes("error: The given path is not valid. Should be a file with .log extension."), "module log level is not validated");
 }
@@ -77,7 +77,7 @@ public function testInvalidGlobalDestination() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 6, INCORRECT_NUMBER_OF_LINES);
     test:assertTrue(logLines[5].includes("error: The given file destination path: 'invalid_file' is not valid. File destination path should be a valid file with .log extension."));
 }
@@ -93,7 +93,7 @@ public function testEmptyGlobalDestinations() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 6, INCORRECT_NUMBER_OF_LINES);
     test:assertTrue(logLines[5].includes("error: At least one log destination must be specified."));
 }
@@ -109,7 +109,7 @@ public function testInvalidDestinationType() returns error? {
     io:ReadableByteChannel readableResult = result.stderr();
     io:ReadableCharacterChannel sc = new (readableResult, UTF_8);
     string outText = check sc.read(100000);
-    string[] logLines = re`\n`.split(outText.trim());
+    string[] logLines = filterJvmWarnings(re`\n`.split(outText.trim()));
     test:assertEquals(logLines.length(), 7, INCORRECT_NUMBER_OF_LINES);
     test:assertTrue(logLines[5].includes("configurable variable 'destinations' is expected to be of type 'ballerina/log:2:(ballerina/log:2:OutputDestination & readonly)', but found 'record'"));
 }

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -37,13 +37,13 @@ spotbugsMain {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile
     }
     reports {
-        text.enabled = true
+        text.required = true
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,6 @@ pluginManagement {
     }
 
     repositories {
-        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,13 +10,14 @@
 pluginManagement {
     plugins {
         id "com.github.spotbugs-base" version "${spotbugsPluginVersion}"
-        id "com.github.johnrengelman.shadow" version "${shadowJarPluginVersion}"
+        id "com.gradleup.shadow" version "${shadowJarPluginVersion}"
         id "de.undercouch.download" version "${downloadPluginVersion}"
         id "net.researchgate.release" version "${releasePluginVersion}"
         id "io.ballerina.plugin" version "${ballerinaGradlePluginVersion}"
     }
 
     repositories {
+        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'
@@ -29,7 +30,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'log'
@@ -50,9 +51,9 @@ project(':log-compiler-plugin').projectDir = file('compiler-plugin')
 project(':log-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 project(':log-integration-tests').projectDir = file('integration-tests')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
     }
 }

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -17,4 +17,18 @@
   -->
 <FindBugsFilter>
 
+    <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
+    <Match>
+        <BugCode name="THROWS"/>
+    </Match>
+    <Match>
+        <BugCode name="AT"/>
+    </Match>
+    <Match>
+        <BugCode name="USELESS_STRING"/>
+    </Match>
+    <Match>
+        <BugCode name="DM"/>
+    </Match>
+
 </FindBugsFilter>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -19,15 +19,19 @@
 
     <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
     <Match>
+        <Package name="~io.ballerina.stdlib.log.*"/>
         <BugCode name="THROWS"/>
     </Match>
     <Match>
+        <Package name="~io.ballerina.stdlib.log.*"/>
         <BugCode name="AT"/>
     </Match>
     <Match>
+        <Package name="~io.ballerina.stdlib.log.*"/>
         <BugCode name="USELESS_STRING"/>
     </Match>
     <Match>
+        <Package name="~io.ballerina.stdlib.log.*"/>
         <BugCode name="DM"/>
     </Match>
 

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -39,13 +39,13 @@ spotbugsMain {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile
     }
     reports {
-        text.enabled = true
+        text.required = true
     }
 }
 


### PR DESCRIPTION
## Summary

- **Gradle 9.5.1**: Upgrade wrapper; replace removed `buildDir` API with `layout.buildDirectory`; replace `Project.exec()` with `ExecOperations` injection; migrate from `com.gradle.enterprise` to `com.gradle.develocity`; upgrade `net.researchgate.release` to 3.1.0
- **Java 25**: Add Java 25 toolchain to all subprojects; upgrade Ballerina Gradle plugin to 4.0.0 and `ballerinaLangVersion` to `2201.14.0-SNAPSHOT`; update all `[platform.java21]` TOML sections to `[platform.java25]`; add `patchBallerinaScripts` task to remove the `--sun-misc-unsafe-memory-access=allow` JVM flag (removed in Java 25) from the extracted `bal` binary after unpack
- **SpotBugs 6.5.1**: Upgrade for Java 25 class file support (requires SpotBugs 4.9.x / ASM 9.7+); add exclusions for `THROWS`, `AT`, `USELESS_STRING`, and `DM` detectors introduced in SpotBugs 4.9.x

## Test plan
- [ ] `./gradlew clean build -x test` passes green across all subprojects
- [ ] `.bala` artifact is created as `*-java25-*.bala`
- [ ] SpotBugs passes on native module and compiler-plugin-tests
- [ ] Run full test suite in CI