### PR TITLE
[DO NOT MERGE] Test Java 21/25 compatibility via ballerina-library dev workflows

### DIFF
--- a/.github/workflows/build-timestamped-master.yml
+++ b/.github/workflows/build-timestamped-master.yml
@@ -14,5 +14,5 @@ jobs:
   call_workflow:
     name: Run Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/build-timestamp-master-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/build-timestamp-master-template.yml@dev
     secrets: inherit

--- a/.github/workflows/build-with-bal-test-graalvm.yml
+++ b/.github/workflows/build-with-bal-test-graalvm.yml
@@ -30,7 +30,7 @@ jobs:
   call_stdlib_workflow:
     name: Run StdLib Workflow
     if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'ballerina-platform') }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/build-with-bal-test-graalvm-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/build-with-bal-test-graalvm-template.yml@dev
     with:
       lang_tag: ${{ inputs.lang_tag }}
       lang_version: ${{ inputs.lang_version }}

--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -15,7 +15,7 @@ jobs:
   call_workflow:
     name: Run Central Publish Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/central-publish-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/central-publish-template.yml@dev
     secrets: inherit
     with:
       environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/process-load-test-result.yml
+++ b/.github/workflows/process-load-test-result.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   call_stdlib_process_load_test_results_workflow:
     name: Run StdLib Process Load Test Results Workflow
-    uses: ballerina-platform/ballerina-library/.github/workflows/process-load-test-results-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/process-load-test-results-template.yml@dev
     with:
       results: ${{ toJson(github.event.client_payload.results) }}
     secrets:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,7 +9,7 @@ jobs:
   call_workflow:
     name: Run Release Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/release-package-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/release-package-template.yml@dev
     secrets: inherit
     with:
       package-name: log

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,5 +10,5 @@ jobs:
   call_workflow:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@dev
     secrets: inherit

--- a/.github/workflows/trigger-load-tests.yml
+++ b/.github/workflows/trigger-load-tests.yml
@@ -22,7 +22,7 @@ jobs:
   call_stdlib_trigger_load_test_workflow:
     name: Run StdLib Load Test Workflow
     if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'ballerina-platform') }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/trigger-load-tests-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/trigger-load-tests-template.yml@dev
     with:
       repo_name: 'module-ballerina-log'
       runtime_artifacts_url: 'https://api.github.com/repos/ballerina-platform/module-ballerina-log/actions/artifacts'

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -9,5 +9,5 @@ jobs:
   call_workflow:
     name: Run Trivy Scan Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/trivy-scan-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/trivy-scan-template.yml@dev
     secrets: inherit

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -15,6 +15,13 @@
  *
  */
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -62,8 +69,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml CompilerPlugin.toml"

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -46,3 +46,5 @@ artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
 artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
+
+test.mustRunAfter(downloadCheckstyleRuleFiles)

--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,6 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn('log-ballerina:build')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,14 @@ release {
     }
 }
 
-tasks.named('build') {
-    dependsOn('log-ballerina:build')
+if (tasks.names.contains('build')) {
+    tasks.named('build') {
+        dependsOn('log-ballerina:build')
+
+    }
+} else {
+    tasks.register('build') {
+        dependsOn('log-ballerina:build')
+
+    }
 }

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -25,7 +25,7 @@ plugins {
 
 jacoco {
     toolVersion = "${jacocoVersion}"
-    reportsDirectory = file("$project.buildDir/reports/jacoco")
+    reportsDirectory = layout.buildDirectory.dir("reports/jacoco")
 }
 
 description = 'Ballerina - Log Compiler Plugin Tests'
@@ -50,7 +50,6 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
 
 test {
     useTestNG() {
@@ -86,7 +85,7 @@ spotbugsTest {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -53,7 +53,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,13 +4,13 @@ version=2.17.1-SNAPSHOT
 ballerinaLangVersion=2201.13.0
 
 checkstylePluginVersion=10.12.0
-spotbugsPluginVersion=6.0.18
+spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.6.0
-ballerinaGradlePluginVersion=2.3.0
+releasePluginVersion=3.1.0
+ballerinaGradlePluginVersion=4.0.0
 balScanVersion=0.11.0
-jacocoVersion=0.8.10
+jacocoVersion=0.8.14
 jacksonDatabindVersion=2.17.2
 
 #stdlib dependencies

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -16,6 +16,13 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 apply plugin: 'java'
 
@@ -140,6 +147,7 @@ task copyTestOutputResources(type: Copy) {
 }
 
 task ballerinaIntegrationTests {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     inputs.dir file(project.projectDir)
     dependsOn(compileTestJava)
     dependsOn(processTestResources)
@@ -157,7 +165,7 @@ task ballerinaIntegrationTests {
         def distributionBinPath =  "$project.rootDir/target/ballerina-runtime/bin"
         setExecPath(configTOMLFile,distributionBinPath)
         setTempDirPath(configTOMLFile, "$tempDir")
-        exec {
+        execHelper.execOperations.exec {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -37,7 +37,7 @@ spotbugsMain {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,7 +29,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'log'
@@ -50,9 +50,9 @@ project(':log-compiler-plugin').projectDir = file('compiler-plugin')
 project(':log-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 project(':log-integration-tests').projectDir = file('integration-tests')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+        termsOfUseAgree = 'yes'
     }
 }

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -39,7 +39,7 @@ spotbugsMain {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile


### PR DESCRIPTION
## Summary
**DO NOT MERGE — this PR exists only to run CI against the `ballerina-library` `dev` branch workflows for Java 21/25 compatibility testing.**

Combines the gradle upgrade from PR 1 with pointing this repo's `ballerina-library` reusable workflows at `dev` instead of `main`. Close (don't merge) once the `dev` branch changes land upstream in `ballerina-library`'s `main` — PR 1 is the one that should land here.

## Test plan
- [ ] CI passes on the `dev` ballerina-library workflows for Java 21 and Java 25
